### PR TITLE
feat: Parse partition_fields from JSON String

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Currently only supports append and merging data. If no key properties are provid
 | `public_key` | string | ❌ | - | Public key for private GCS and S3 storage authentication (optional) |
 | `secret_key` | string | ❌ | - | Secret key for private GCS and S3 storage authentication (optional) |
 | `region` | string | ❌ | - | AWS region for S3 storage type (required when using S3 with explicit credentials) |
-| `default_target_schema` | string | ❌ | - | Default database schema where data should be written. If not provided schema will attempt to be derived from the stream name |
+| `default_target_schema` | string | ❌ | - | Default database schema where data should be written. If not provided schema will attempt to be inferred from the stream name (inferring schema only works for database extractors ) |
 | `target_schema_prefix` | string | ❌ | - | Prefix to add to the target schema name. If not provided, no prefix will be added |
 | `add_record_metadata` | boolean | ❌ | `false` | When True, automatically adds Singer Data Capture (SDC) metadata columns to target tables |
 | `flatten_max_level` | integer | ❌ | `0` | Maximum depth for flattening nested fields. Set to 0 to disable flattening |

--- a/target_ducklake/sinks.py
+++ b/target_ducklake/sinks.py
@@ -89,6 +89,7 @@ class ducklakeSink(BatchSink):
             return self.config.get("default_target_schema")  # type: ignore
         else:
             # if no default target schema is provided, try to derive it from the stream name
+            # only works for database extractors (eg public-users becomes public.users)
             stream_name_dict = stream_name_to_dict(self.stream_name)
             if stream_name_dict.get("schema_name"):
                 if self.config.get("target_schema_prefix"):


### PR DESCRIPTION
If passing in object configs as env vars they will be strings, so we add a check and convert from string to dict if necessary.
This PR also explains in the README how destination schema inference works.