### PR TITLE
feat: Support multi-key primary keys, deduplicate before writing temp file

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Currently only supports append and merging data. If no key properties are provid
 
 ## TODOs
 
-- support merging when stream has multiple key properties (currently only supports one key property)
 - support deleting data from the target or setting _sdc_deleted_at field (example use-case: syncing from Postgres using log-based change data capture)
 
 ## Configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ license-files = [ "LICENSE" ]
 requires-python = ">=3.9"
 dependencies = [
     "duckdb>=1.3.2",
+    "polars>=1.31.0",
     "pyarrow>=20.0.0",
     "ruff>=0.12.5",
     "singer-sdk[faker]~=0.46.4",

--- a/target_ducklake/target.py
+++ b/target_ducklake/target.py
@@ -120,18 +120,17 @@ class Targetducklake(Target):
         ),
         th.Property(
             "flatten_max_level",
-            th.CustomType({
-                "anyOf": [
-                    {
-                        "type": "string",
-                        "description": "String representation of flatten max level"
-                    },
-                    {
-                        "type": "integer",
-                        "minimum": 0
-                    }
-                ]
-            }),
+            th.CustomType(
+                {
+                    "anyOf": [
+                        {
+                            "type": "string",
+                            "description": "String representation of flatten max level",
+                        },
+                        {"type": "integer", "minimum": 0},
+                    ]
+                }
+            ),
             default=0,
             title="Flattening Max Level",
             description="Maximum depth for flattening nested fields. Set to 0 to disable flattening.",
@@ -145,18 +144,17 @@ class Targetducklake(Target):
         ),
         th.Property(
             "max_batch_size",
-            th.CustomType({
-                "anyOf": [
-                    {
-                        "type": "string",
-                        "description": "String representation of max batch size"
-                    },
-                    {
-                        "type": "integer",
-                        "minimum": 1
-                    }
-                ]
-            }),
+            th.CustomType(
+                {
+                    "anyOf": [
+                        {
+                            "type": "string",
+                            "description": "String representation of max batch size",
+                        },
+                        {"type": "integer", "minimum": 1},
+                    ]
+                }
+            ),
             default=10000,
             title="Max Batch Size",
             description="Maximum number of records to process in a single batch",

--- a/uv.lock
+++ b/uv.lock
@@ -871,6 +871,20 @@ wheels = [
 ]
 
 [[package]]
+name = "polars"
+version = "1.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/f5/de1b5ecd7d0bd0dd87aa392937f759f9cc3997c5866a9a7f94eabf37cd48/polars-1.31.0.tar.gz", hash = "sha256:59a88054a5fc0135386268ceefdbb6a6cc012d21b5b44fed4f1d3faabbdcbf32", size = 4681224 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/6e/bdd0937653c1e7a564a09ae3bc7757ce83fedbf19da600c8b35d62c0182a/polars-1.31.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:ccc68cd6877deecd46b13cbd2663ca89ab2a2cb1fe49d5cfc66a9cef166566d9", size = 34511354 },
+    { url = "https://files.pythonhosted.org/packages/77/fe/81aaca3540c1a5530b4bc4fd7f1b6f77100243d7bb9b7ad3478b770d8b3e/polars-1.31.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:a94c5550df397ad3c2d6adc212e59fd93d9b044ec974dd3653e121e6487a7d21", size = 31377712 },
+    { url = "https://files.pythonhosted.org/packages/b8/d9/5e2753784ea30d84b3e769a56f5e50ac5a89c129e87baa16ac0773eb4ef7/polars-1.31.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ada7940ed92bea65d5500ae7ac1f599798149df8faa5a6db150327c9ddbee4f1", size = 35050729 },
+    { url = "https://files.pythonhosted.org/packages/20/e8/a6bdfe7b687c1fe84bceb1f854c43415eaf0d2fdf3c679a9dc9c4776e462/polars-1.31.0-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:b324e6e3e8c6cc6593f9d72fe625f06af65e8d9d47c8686583585533a5e731e1", size = 32260836 },
+    { url = "https://files.pythonhosted.org/packages/6e/f6/9d9ad9dc4480d66502497e90ce29efc063373e1598f4bd9b6a38af3e08e7/polars-1.31.0-cp39-abi3-win_amd64.whl", hash = "sha256:3fd874d3432fc932863e8cceff2cff8a12a51976b053f2eb6326a0672134a632", size = 35156211 },
+    { url = "https://files.pythonhosted.org/packages/40/4b/0673a68ac4d6527fac951970e929c3b4440c654f994f0c957bd5556deb38/polars-1.31.0-cp39-abi3-win_arm64.whl", hash = "sha256:62ef23bb9d10dca4c2b945979f9a50812ac4ace4ed9e158a6b5d32a7322e6f75", size = 31469078 },
+]
+
+[[package]]
 name = "propcache"
 version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1522,6 +1536,7 @@ version = "0.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "duckdb" },
+    { name = "polars" },
     { name = "pyarrow" },
     { name = "ruff" },
     { name = "singer-sdk", extra = ["faker"] },
@@ -1546,6 +1561,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "duckdb", specifier = ">=1.3.2" },
+    { name = "polars", specifier = ">=1.31.0" },
     { name = "pyarrow", specifier = ">=20.0.0" },
     { name = "ruff", specifier = ">=0.12.5" },
     { name = "s3fs", marker = "extra == 's3'", specifier = "~=2025.5.0" },


### PR DESCRIPTION
This PR supports merging with multi-key primary keys. We also now deduplicate the temp parquet files based on key properties; this handles the case where an API returns duplicate records in the same call and `batch_size` is not reached yet (Stripe API does this).