### PR TITLE
chore: bump ducklake max_retry_count

### DIFF
--- a/target_ducklake/connector.py
+++ b/target_ducklake/connector.py
@@ -140,6 +140,7 @@ class DuckLakeConnector:
         script_parts = [
             "INSTALL ducklake;",
             "INSTALL postgres;",
+            "SET ducklake_max_retry_count=100;",
         ]
 
         if self.catalog_type == "duckdb":


### PR DESCRIPTION
Potential fix for primary key conflict due to writing to ducklake concurrently. Suggested solution from here:
https://github.com/duckdb/ducklake/issues/284#issuecomment-3078196221