### PR TITLE
feat: add config for validate_records

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Currently only supports append and merging data. If no key properties are provid
 | `max_batch_size` | integer | ❌ | `10000` | Maximum number of records to process in a single batch |
 | `partition_fields` | object | ❌ | - | Object mapping stream names to arrays of partition column definitions. Each stream key maps directly to an array of column definitions |
 | `auto_cast_timestamps` | boolean | ❌ | `false` | When True, automatically attempts to cast timestamp-like fields to timestamp types in ducklake |
+| `validate_records` | boolean | ❌ | `false` | Whether to validate the schema of the incoming streams |
 
 ### Example Meltano YAML Configuration
 

--- a/meltano.yml
+++ b/meltano.yml
@@ -113,5 +113,11 @@ plugins:
       description: When True, automatically attempts to cast timestamp-like fields to timestamp types in ducklake.
       default: false
 
+    - name: validate_records
+      kind: boolean
+      label: Validate Records
+      description: Whether to validate the schema of the incoming streams.
+      default: false
+
     settings_group_validation:
     - [catalog_url, data_path]

--- a/target_ducklake/target.py
+++ b/target_ducklake/target.py
@@ -223,6 +223,13 @@ class Targetducklake(Target):
                 "When True, automatically attempts to cast timestamp-like fields to timestamp types in ducklake."
             ),
         ),
+        th.Property(
+            "validate_records",
+            th.BooleanType(),
+            default=False,
+            title="Validate Records",
+            description="Whether to validate the schema of the incoming streams.",
+        ),
     ).to_dict()
 
     default_sink_class = ducklakeSink


### PR DESCRIPTION
Defaults to false. Won't validate incoming records against schema. The default behavior is same as other major targets:
https://github.com/MeltanoLabs/target-snowflake
https://github.com/MeltanoLabs/target-postgres
https://github.com/jwills/target-duckdb
