### PR TITLE
feat: Option to overwrite table if no PK is provided, optimize prepare table call

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Currently only supports append and merging data. If no key properties are provid
 | `partition_fields` | object | ❌ | - | Object mapping stream names to arrays of partition column definitions. Each stream key maps directly to an array of column definitions |
 | `auto_cast_timestamps` | boolean | ❌ | `false` | When True, automatically attempts to cast timestamp-like fields to timestamp types in ducklake |
 | `validate_records` | boolean | ❌ | `false` | Whether to validate the schema of the incoming streams |
+| `overwrite_if_no_pk` | boolean | ❌ | `false` | When True, truncates the target table before inserting records if no primary keys are defined in the stream |
 
 ### Example Meltano YAML Configuration
 
@@ -52,6 +53,7 @@ plugins:
         max_batch_size: 10000 # Optional (default 10000)
         add_record_metadata: true # Optional
         auto_cast_timestamps: true # Optional
+        overwrite_if_no_pk: true # Optional (default false)
         partition_fields: {"my_stream": [{"column_name": "created_at", "type": "timestamp", "granularity": ["year", "month"]}]} # Optional
 ```
 

--- a/meltano.yml
+++ b/meltano.yml
@@ -119,5 +119,11 @@ plugins:
       description: Whether to validate the schema of the incoming streams.
       default: false
 
+    - name: overwrite_if_no_pk
+      kind: boolean
+      label: Overwrite If No Primary Key
+      description: When True, truncates the target table before inserting records if no primary keys are defined in the stream.
+      default: false
+
     settings_group_validation:
     - [catalog_url, data_path]

--- a/target_ducklake/target.py
+++ b/target_ducklake/target.py
@@ -130,12 +130,9 @@ class Targetducklake(Target):
         ),
         th.Property(
             "flatten_max_level",
-            th.CustomType({
-                "oneOf": [
-                    {"type": "string"},
-                    {"type": "integer", "minimum": 0}
-                ]
-            }),
+            th.CustomType(
+                {"oneOf": [{"type": "string"}, {"type": "integer", "minimum": 0}]}
+            ),
             default=0,
             title="Flattening Max Level",
             description="Maximum depth for flattening nested fields. Set to 0 to disable flattening.",
@@ -229,6 +226,13 @@ class Targetducklake(Target):
             default=False,
             title="Validate Records",
             description="Whether to validate the schema of the incoming streams.",
+        ),
+        th.Property(
+            "overwrite_if_no_pk",
+            th.BooleanType(),
+            default=False,
+            title="Overwrite If No Primary Key",
+            description="When True, truncates the target table before inserting records if no primary keys are defined in the stream.",
         ),
     ).to_dict()
 


### PR DESCRIPTION
- option to truncate table before loading if keys are provided
- optimize Sink so that prepare_table function is only called once at the start of sink initialization (assumes columns are uniform across all create temp files)