### PR TITLE
Add fallback quarantine and timestamp coercion options

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,17 @@ Supports append, merge, and overwrite load methods (default is merge). The load 
 | `flatten_max_level` | integer | ❌ | `0` | Maximum depth for flattening nested fields. Set to 0 to disable flattening |
 | `temp_file_dir` | string | ❌ | `"temp_files/"` | Directory path for storing temporary parquet files |
 | `max_batch_size` | integer | ❌ | `10000` | Maximum number of records to process in a single batch |
+| `fallback_on_insert_error` | boolean | ❌ | `false` | When true, quarantines failed batches to Parquet instead of failing immediately |
+| `fallback_dir` | string | ❌ | `<data_path>/_failed_batches/` | Directory where quarantined batch artifacts are written |
+| `fallback_include_payload` | boolean | ❌ | `true` | Also write the raw Singer RECORD payloads as `records.jsonl` when quarantining |
+| `advance_state_on_fallback` | boolean | ❌ | `false` | Continue processing and advance state after quarantine instead of re-raising |
 | `partition_fields` | object | ❌ | - | Object mapping stream names to arrays of partition column definitions. Each stream key maps directly to an array of column definitions |
 | `auto_cast_timestamps` | boolean | ❌ | `false` | When True, automatically attempts to cast timestamp-like fields to timestamp types in ducklake |
+| `sanitize_timezones` | boolean | ❌ | follows `auto_cast_timestamps` | Normalize timezone-aware values and UTC±HH:MM strings before Arrow ingestion |
+| `dates_to_varchar` | boolean | ❌ | `false` | Force timestamp-like columns to VARCHAR to avoid timezone and formatting issues |
+| `dates_to_varchar_streams` | array | ❌ | - | List of stream names whose timestamp-like columns should be coerced to VARCHAR |
+| `dates_to_varchar_columns` | object | ❌ | - | Mapping of stream name to explicit column names to coerce to VARCHAR |
+| `dates_to_varchar_glob` | array | ❌ | - | Glob patterns that match column names to coerce to VARCHAR |
 | `validate_records` | boolean | ❌ | `false` | Whether to validate the schema of the incoming streams |
 | `overwrite_if_no_pk` | boolean | ❌ | `false` | When True, truncates the target table before inserting records if no primary keys are defined in the stream. Overrides load_method. |
 
@@ -57,7 +66,52 @@ plugins:
         auto_cast_timestamps: true # Optional
         overwrite_if_no_pk: true # Optional (default false)
         partition_fields: {"my_stream": [{"column_name": "created_at", "type": "timestamp", "granularity": ["year", "month"]}]} # Optional
+        fallback_on_insert_error: true # Optional - quarantine failed batches instead of failing immediately
+        fallback_dir: ${MELTANO_PROJECT_ROOT}/.ducklake/_failed_batches # Optional override
+        fallback_include_payload: true # Optional - also write raw Singer payloads
+        sanitize_timezones: true # Optional - normalize UTC±HH:MM style strings
+        dates_to_varchar: true # Optional - force timestamp-like columns to VARCHAR
 ```
+
+### Resilient loading
+
+When `fallback_on_insert_error` is enabled, each failing batch is quarantined to
+`<fallback_dir>/<stream>/<UTC timestamp>/` with:
+
+- `batch.parquet` – the sanitized records written out as Parquet.
+- `meta.json` – error metadata, schema details, and relevant configuration.
+- `records.jsonl` – optional Singer RECORD payloads (enabled by
+  `fallback_include_payload`).
+
+`sanitize_timezones` converts timezone-aware Python datetimes and `UTC±HH:MM`
+style strings to UTC-naive ISO strings before Arrow ingestion. The
+`dates_to_varchar*` settings coerce timestamp-like columns to VARCHAR so DuckDB
+never has to parse problematic formats. Each coerced column increments the
+`target_ducklake_dates_to_varchar_columns_total{stream}` metric, while each
+quarantined batch increments
+`target_ducklake_fallback_batches_total{stream}`.
+
+### Quarantine & Replay
+
+Quarantined Parquet files can be replayed transactionally with DuckLake once the
+bad data has been reviewed:
+
+```sql
+-- Setup
+INSTALL ducklake; LOAD ducklake;
+
+-- Attach your catalog (and data path) as usual
+ATTACH 'ducklake:POSTGRES://…' AS dl (DATA_PATH 'gs://…');
+
+-- Register quarantined file(s):
+SELECT ducklake_add_data_files(
+  'FACEBOOKADS.creatives',
+  ['gs://def-ducklake/.../_failed_batches/creatives/2025-10-04T19-33-58Z/batch.parquet']
+);
+```
+
+DuckLake registers (rather than copies) the files so ownership transfers to the
+catalog and future compaction can clean them up.
 
 ### Partitioning
 

--- a/meltano.yml
+++ b/meltano.yml
@@ -96,6 +96,29 @@ plugins:
       description: Maximum number of records to process in a single batch
       default: 10000
 
+    - name: fallback_on_insert_error
+      kind: boolean
+      label: Quarantine Failed Batches
+      description: When true, write failing batches to a fallback directory before raising.
+      default: false
+
+    - name: fallback_dir
+      kind: string
+      label: Fallback Directory
+      description: Directory where quarantined batches are written (defaults to <data_path>/_failed_batches/).
+
+    - name: fallback_include_payload
+      kind: boolean
+      label: Include Raw Payload in Fallback
+      description: When true, also write raw Singer RECORD payloads as records.jsonl in the fallback directory.
+      default: true
+
+    - name: advance_state_on_fallback
+      kind: boolean
+      label: Advance State After Fallback
+      description: Continue processing and advance state even when a batch was quarantined.
+      default: false
+
     - name: add_record_metadata
       kind: boolean
       label: Add Record Metadata
@@ -113,6 +136,11 @@ plugins:
       description: When True, automatically attempts to cast timestamp-like fields to timestamp types in ducklake.
       default: false
 
+    - name: sanitize_timezones
+      kind: boolean
+      label: Sanitize Timezones
+      description: Normalize timezone-aware values and UTC±HH:MM strings before Arrow ingestion. Defaults to auto_cast_timestamps when unset.
+
     - name: validate_records
       kind: boolean
       label: Validate Records
@@ -127,6 +155,27 @@ plugins:
         - append
         - merge
         - overwrite
+
+    - name: dates_to_varchar
+      kind: boolean
+      label: Dates to VARCHAR
+      description: Force timestamp-like columns to VARCHAR before ingestion to avoid timezone issues.
+      default: false
+
+    - name: dates_to_varchar_streams
+      kind: array
+      label: Streams for Dates to VARCHAR
+      description: List of stream names whose timestamp-like columns should be coerced to VARCHAR when enabled.
+
+    - name: dates_to_varchar_columns
+      kind: object
+      label: Columns for Dates to VARCHAR
+      description: Mapping of stream name to explicit column names that should be coerced to VARCHAR.
+
+    - name: dates_to_varchar_glob
+      kind: array
+      label: Column Patterns for Dates to VARCHAR
+      description: Glob patterns that match column names which should be coerced to VARCHAR.
 
     - name: overwrite_if_no_pk
       kind: boolean

--- a/target_ducklake/sinks.py
+++ b/target_ducklake/sinks.py
@@ -2,11 +2,17 @@
 
 from __future__ import annotations
 
+import fnmatch
+import json
 import os
+import re
 import shutil
+import traceback
 from collections.abc import Sequence
 from datetime import datetime, timezone
 from decimal import Decimal
+from pathlib import Path
+from typing import Any
 
 import polars as pl
 import pyarrow.parquet as pq
@@ -16,11 +22,22 @@ from singer_sdk import Target
 from singer_sdk.sinks import BatchSink
 
 from target_ducklake.connector import DuckLakeConnector
-from target_ducklake.flatten import flatten_record, flatten_schema
+from target_ducklake.flatten import (
+    CustomJSONEncoder,
+    TIMESTAMP_COLUMN_NAMES,
+    flatten_record,
+    flatten_schema,
+)
 from target_ducklake.parquet_utils import (
     concat_tables,
     flatten_schema_to_pyarrow_schema,
 )
+
+UTC_OFFSET_PATTERN = re.compile(r"^(?P<prefix>.+?)\s*UTC(?P<offset>[+-]\d{2}:\d{2})$")
+DEFAULT_TIMESTAMP_GLOBS = ("*_at", "*_time", "*timestamp*", "*_date")
+FALLBACK_PARQUET_FILENAME = "batch.parquet"
+FALLBACK_META_FILENAME = "meta.json"
+FALLBACK_RECORDS_FILENAME = "records.jsonl"
 
 
 class ducklakeSink(BatchSink):
@@ -37,6 +54,42 @@ class ducklakeSink(BatchSink):
         self.temp_file_dir = self.config.get("temp_file_dir", "temp_files/")
         self.files_saved = 0
 
+        self.fallback_on_insert_error = self.config.get(
+            "fallback_on_insert_error", False
+        )
+        self.fallback_include_payload = self.config.get(
+            "fallback_include_payload", True
+        )
+        self.advance_state_on_fallback = self.config.get(
+            "advance_state_on_fallback", False
+        )
+        data_path = self.config.get("data_path", "")
+        default_fallback_dir = (
+            os.path.join(data_path, "_failed_batches") if data_path else "_failed_batches"
+        )
+        self.fallback_dir = self.config.get("fallback_dir") or default_fallback_dir
+
+        self.flatten_max_level = self.config.get("flatten_max_level", 0)
+        self.auto_cast_timestamps = self.config.get("auto_cast_timestamps", False)
+        self.sanitize_timezones = self.config.get(
+            "sanitize_timezones", self.auto_cast_timestamps
+        )
+
+        self.dates_to_varchar_enabled = self.config.get("dates_to_varchar", False)
+        streams_cfg = self.config.get("dates_to_varchar_streams", []) or []
+        self.dates_to_varchar_streams = set(streams_cfg)
+        columns_cfg = self.config.get("dates_to_varchar_columns", {}) or {}
+        self.dates_to_varchar_columns = {
+            stream: set(columns) for stream, columns in columns_cfg.items()
+        }
+        glob_cfg = self.config.get("dates_to_varchar_glob", []) or []
+        self.dates_to_varchar_glob = list(glob_cfg)
+
+        self._varchar_columns: set[str] = set()
+        self._columns_warned_for_varchar: set[str] = set()
+        self._tz_warning_emitted = False
+        self._emitted_metrics: list[tuple[str, dict[str, Any]]] = []
+
         # NOTE: we probably don't need all this logging, but useful for debugging while target is in development
         # Log original schema for debugging
         self.logger.info(f"Original schema for stream '{stream_name}': {self.schema}")
@@ -45,13 +98,12 @@ class ducklakeSink(BatchSink):
         self.connector = DuckLakeConnector(dict(self.config))
 
         # Create pyarrow and Ducklake schemas
-        self.flatten_max_level = self.config.get("flatten_max_level", 0)
-        self.auto_cast_timestamps = self.config.get("auto_cast_timestamps", False)
         self.flatten_schema = flatten_schema(
             self.schema,
             max_level=self.flatten_max_level,
             auto_cast_timestamps=self.auto_cast_timestamps,
         )
+        self._apply_dates_to_varchar_overrides()
         # Log flattened schema for debugging
         self.logger.info(
             f"Flattened schema for stream '{stream_name}': {self.flatten_schema}"
@@ -95,6 +147,272 @@ class ducklakeSink(BatchSink):
                 f"Load method is {self.load_method} for {self.stream_name}"
             )
             self.should_overwrite_table = False
+
+    def _apply_dates_to_varchar_overrides(self) -> None:
+        """Mutate the flattened schema to coerce timestamp-like columns to string."""
+
+        if not (
+            self.dates_to_varchar_enabled
+            or self.dates_to_varchar_streams
+            or self.dates_to_varchar_columns
+            or self.dates_to_varchar_glob
+        ):
+            return
+
+        coerced_columns: list[str] = []
+        for column_name, schema_entry in list(self.flatten_schema.items()):
+            if self._should_coerce_column(column_name, schema_entry):
+                self._coerce_schema_entry_to_string(column_name, schema_entry)
+                coerced_columns.append(column_name)
+
+        if coerced_columns:
+            self.logger.info(
+                "Coercing columns to VARCHAR for stream %s: %s",
+                self.stream_name,
+                ", ".join(sorted(coerced_columns)),
+            )
+
+    def _should_coerce_column(self, column_name: str, schema_entry: dict) -> bool:
+        """Determine if a column should be coerced to VARCHAR."""
+
+        stream_specific = self.dates_to_varchar_columns.get(self.stream_name, set())
+        if column_name in stream_specific:
+            return True
+
+        for pattern in self.dates_to_varchar_glob:
+            if fnmatch.fnmatch(column_name, pattern):
+                return True
+
+        if self.stream_name in self.dates_to_varchar_streams and self._is_timestamp_like(
+            column_name, schema_entry
+        ):
+            return True
+
+        if self.dates_to_varchar_enabled and self._is_timestamp_like(
+            column_name, schema_entry
+        ):
+            return True
+
+        return False
+
+    def _is_timestamp_like(self, column_name: str, schema_entry: dict) -> bool:
+        """Best-effort detection of timestamp-like columns."""
+
+        fmt = schema_entry.get("format")
+        if isinstance(fmt, str) and fmt in {"date-time", "date"}:
+            return True
+
+        entry_type = schema_entry.get("type")
+        if isinstance(entry_type, list):
+            types = {str(t).lower() for t in entry_type}
+        elif isinstance(entry_type, str):
+            types = {entry_type.lower()}
+        else:
+            types = set()
+
+        lower_name = column_name.lower()
+        if lower_name in TIMESTAMP_COLUMN_NAMES:
+            return True
+
+        for pattern in DEFAULT_TIMESTAMP_GLOBS:
+            if fnmatch.fnmatch(lower_name, pattern):
+                return True
+
+        if types.intersection({"string", "integer", "number"}):
+            if lower_name.endswith("_at") or lower_name.endswith("_time"):
+                return True
+
+        return False
+
+    def _coerce_schema_entry_to_string(
+        self, column_name: str, schema_entry: dict
+    ) -> None:
+        """Update schema entry to coerce to VARCHAR and record metrics."""
+
+        entry_type = schema_entry.get("type")
+        if isinstance(entry_type, list):
+            normalized_types = [str(t).lower() for t in entry_type]
+            has_null = "null" in normalized_types
+        elif isinstance(entry_type, str):
+            normalized_types = [entry_type.lower()]
+            has_null = entry_type.lower() == "null"
+        else:
+            normalized_types = []
+            has_null = False
+
+        if has_null:
+            schema_entry["type"] = ["null", "string"]
+        else:
+            schema_entry["type"] = "string"
+
+        original_format = schema_entry.get("format")
+        schema_entry.pop("format", None)
+
+        self.flatten_schema[column_name] = schema_entry
+        if column_name not in self._varchar_columns:
+            self._varchar_columns.add(column_name)
+            self._increment_metric(
+                "target_ducklake_dates_to_varchar_columns_total",
+                {"stream": self.stream_name},
+            )
+
+        if (
+            original_format in {"date", "date-time"}
+            and column_name not in self._columns_warned_for_varchar
+        ):
+            self.logger.warning(
+                "Coercing %s.%s declared with format '%s' to VARCHAR due to configuration",
+                self.stream_name,
+                column_name,
+                original_format,
+            )
+            self._columns_warned_for_varchar.add(column_name)
+
+    def _sanitize_records(self, records: list[dict[str, Any]]) -> None:
+        """Normalize timezone information in-place for the provided records."""
+
+        if not self.sanitize_timezones:
+            return
+
+        for record in records:
+            for key, value in list(record.items()):
+                sanitized = self._sanitize_value(value, key)
+                record[key] = sanitized
+
+    def _sanitize_value(self, value: Any, column_name: str) -> Any:
+        """Sanitize a single field value for timezone anomalies."""
+
+        if isinstance(value, datetime):
+            if value.tzinfo is not None:
+                sanitized = value.astimezone(timezone.utc).replace(tzinfo=None)
+                return sanitized.isoformat()
+            return value
+
+        if isinstance(value, str):
+            normalized = self._normalize_non_iana_timezone(value)
+            if normalized is not None:
+                if not self._tz_warning_emitted:
+                    self.logger.warning(
+                        "Non-IANA timezone detected in stream %s (column %s) with sample '%s'; coercing to UTC",
+                        self.stream_name,
+                        column_name,
+                        value,
+                    )
+                    self._tz_warning_emitted = True
+                return normalized
+
+        return value
+
+    def _normalize_non_iana_timezone(self, value: str) -> str | None:
+        """Return a UTC-normalized ISO string for UTC±HH:MM patterns."""
+
+        match = UTC_OFFSET_PATTERN.match(value.strip())
+        if not match:
+            return None
+
+        prefix = match.group("prefix").strip()
+        offset = match.group("offset")
+        iso_candidate = f"{prefix}{offset}"
+        try:
+            parsed = datetime.fromisoformat(iso_candidate)
+        except ValueError:
+            return None
+
+        if parsed.tzinfo is None:
+            return None
+
+        normalized = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+        return normalized.isoformat()
+
+    def _coerce_records_to_varchar(self, records: list[dict[str, Any]]) -> None:
+        """Ensure configured VARCHAR columns contain string values."""
+
+        if not self._varchar_columns:
+            return
+
+        for record in records:
+            for column in self._varchar_columns:
+                if column in record and record[column] is not None:
+                    record[column] = self._stringify_value(record[column])
+
+    def _stringify_value(self, value: Any) -> str:
+        if isinstance(value, datetime):
+            return value.isoformat()
+        return str(value)
+
+    def _increment_metric(self, metric_name: str, labels: dict[str, Any]) -> None:
+        """Record metrics for observability while tolerating missing clients."""
+
+        self._emitted_metrics.append((metric_name, labels))
+        metrics_client = getattr(self, "metrics", None)
+        if metrics_client is None:
+            return
+
+        try:
+            counter = metrics_client.counter(metric_name, labels)
+            counter.increment(1)
+        except AttributeError:
+            try:
+                metrics_client.increment(metric_name, 1, labels)
+            except AttributeError:
+                self.logger.debug(
+                    "Metrics client does not support incrementing %s", metric_name
+                )
+
+    def _handle_batch_failure(
+        self,
+        pyarrow_table,
+        raw_records: list[dict[str, Any]],
+        error: Exception,
+    ) -> Path:
+        """Persist failed batch artifacts for later replay."""
+
+        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
+        batch_dir = Path(self.fallback_dir) / self.stream_name / timestamp
+        batch_dir.mkdir(parents=True, exist_ok=True)
+
+        parquet_path = batch_dir / FALLBACK_PARQUET_FILENAME
+        if pyarrow_table is not None:
+            pq.write_table(pyarrow_table, parquet_path.as_posix())
+
+        meta_path = batch_dir / FALLBACK_META_FILENAME
+        meta = {
+            "stream": self.stream_name,
+            "row_count": 0 if pyarrow_table is None else pyarrow_table.num_rows,
+            "schema": self.flatten_schema,
+            "error": {"type": type(error).__name__, "message": str(error)},
+            "traceback": traceback.format_exception_only(type(error), error),
+            "settings": {
+                "fallback_on_insert_error": self.fallback_on_insert_error,
+                "advance_state_on_fallback": self.advance_state_on_fallback,
+                "fallback_include_payload": self.fallback_include_payload,
+                "sanitize_timezones": self.sanitize_timezones,
+                "dates_to_varchar": self.dates_to_varchar_enabled,
+            },
+        }
+        meta_path.write_text(json.dumps(meta, indent=2), encoding="utf-8")
+
+        if self.fallback_include_payload and raw_records:
+            records_path = batch_dir / FALLBACK_RECORDS_FILENAME
+            with records_path.open("w", encoding="utf-8") as records_file:
+                for record in raw_records:
+                    records_file.write(
+                        json.dumps(record, cls=CustomJSONEncoder, ensure_ascii=False)
+                    )
+                    records_file.write("\n")
+
+        self.logger.error(
+            "Quarantined failed batch for %s at %s due to %s: %s",
+            self.stream_name,
+            batch_dir,
+            type(error).__name__,
+            error,
+        )
+        self._increment_metric(
+            "target_ducklake_fallback_batches_total",
+            {"stream": self.stream_name},
+        )
+        return batch_dir
 
     @property
     def target_schema(self) -> str:
@@ -165,6 +483,8 @@ class ducklakeSink(BatchSink):
 
     def process_record(self, record: dict, context: dict) -> None:
         """Process the record and flatten if necessary."""
+        raw_copy = json.loads(json.dumps(record, cls=CustomJSONEncoder))
+        context.setdefault("_raw_records", []).append(raw_copy)
         record_flatten = flatten_record(
             record,
             flatten_schema=self.flatten_schema,
@@ -200,14 +520,17 @@ class ducklakeSink(BatchSink):
 
         return pyarrow_df
 
-    def write_temp_file(self, context: dict) -> str:
+    def write_temp_file(self, context: dict):
         """Write the current batch to a temporary parquet file."""
         self.logger.info(
             f"Writing batch for {self.stream_name} with {len(context['records'])} records to parquet file."
         )
         pyarrow_df = None
+        records = context.get("records", [])
+        self._sanitize_records(records)
+        self._coerce_records_to_varchar(records)
         pyarrow_df = concat_tables(
-            context.get("records", []),
+            records,
             pyarrow_df,
             self.pyarrow_schema,  # type: ignore
         )
@@ -219,7 +542,7 @@ class ducklakeSink(BatchSink):
         self.logger.info(
             f"Batch pyarrow table has ({len(pyarrow_df)} rows)"  # type: ignore
         )
-        del context["records"]
+        context["records"] = []
 
         # Ensure temp directory exists
         os.makedirs(self.temp_file_dir, exist_ok=True)
@@ -235,7 +558,7 @@ class ducklakeSink(BatchSink):
             self.files_saved += 1
             row_count = len(pyarrow_df) if pyarrow_df is not None else 0
             self.logger.info(f"Successfully wrote {row_count} rows to {file_name}")
-            return full_temp_file_path
+            return full_temp_file_path, pyarrow_df
         except Exception as e:
             self.logger.error(
                 f"Failed to write parquet file {full_temp_file_path}: {e}"
@@ -246,8 +569,9 @@ class ducklakeSink(BatchSink):
         """Process a batch of records."""
 
         # first write each batch to a parquet file
-        temp_file_path = self.write_temp_file(context)
+        temp_file_path, pyarrow_df = self.write_temp_file(context)
         self.logger.info(f"Temp file path: {temp_file_path}")
+        raw_records = context.pop("_raw_records", [])
 
         # get the columns from the file and the table
         file_columns = [col["name"] for col in self.ducklake_schema]
@@ -257,32 +581,39 @@ class ducklakeSink(BatchSink):
 
         # If no key properties, load method is append or overwrite, or table should be overwritten
         # we simply insert the data. Table is already truncated in setup if load method is overwrite
-        if (
-            not self.key_properties
-            or self.load_method in ["append", "overwrite"]
-            or self.should_overwrite_table
-        ):
-            self.connector.insert_into_table(
-                temp_file_path,
-                self.target_schema,
-                self.target_table,
-                file_columns,
-                table_columns,
-            )
+        try:
+            if (
+                not self.key_properties
+                or self.load_method in ["append", "overwrite"]
+                or self.should_overwrite_table
+            ):
+                self.connector.insert_into_table(
+                    temp_file_path,
+                    self.target_schema,
+                    self.target_table,
+                    file_columns,
+                    table_columns,
+                )
 
-        # If load method is merge, we merge the data
-        elif self.load_method == "merge":
-            self.connector.merge_into_table(
-                temp_file_path,
-                self.target_schema,
-                self.target_table,
-                file_columns,
-                table_columns,
-                self.key_properties,
-            )
-
-        # delete file after insert
-        os.remove(temp_file_path)
+            # If load method is merge, we merge the data
+            elif self.load_method == "merge":
+                self.connector.merge_into_table(
+                    temp_file_path,
+                    self.target_schema,
+                    self.target_table,
+                    file_columns,
+                    table_columns,
+                    self.key_properties,
+                )
+        except Exception as exc:
+            if self.fallback_on_insert_error:
+                self._handle_batch_failure(pyarrow_df, raw_records, exc)
+                if self.advance_state_on_fallback:
+                    return
+            raise
+        finally:
+            if os.path.exists(temp_file_path):
+                os.remove(temp_file_path)
 
     def __del__(self) -> None:
         """Cleanup when sink is destroyed."""

--- a/target_ducklake/target.py
+++ b/target_ducklake/target.py
@@ -31,19 +31,45 @@ class Targetducklake(Target):
             logging.info(
                 f"Successfully parsed partition_fields from string to object: {parsed_partition_fields}"
             )
+
+        def _parse_literal_if_string(key: str) -> None:
+            if key in config and isinstance(config[key], str):
+                try:
+                    config[key] = ast.literal_eval(config[key])
+                except (ValueError, SyntaxError):
+                    logging.warning(
+                        "Failed to parse %s from string; keeping original value", key
+                    )
+
+        for literal_key in (
+            "dates_to_varchar_streams",
+            "dates_to_varchar_columns",
+            "dates_to_varchar_glob",
+        ):
+            _parse_literal_if_string(literal_key)
+
         if "max_batch_size" in config:
             logging.warning(f"max_batch_size: {config.get('max_batch_size')}")
             config["max_batch_size"] = int(config.get("max_batch_size", 10000))
         if "flatten_max_level" in config:
             config["flatten_max_level"] = int(config.get("flatten_max_level", 0))
-        if "validate_records" in config and isinstance(config["validate_records"], str):
-            config["validate_records"] = config["validate_records"].lower() == "true"
-        if "overwrite_if_no_pk" in config and isinstance(
-            config["overwrite_if_no_pk"], str
-        ):
-            config["overwrite_if_no_pk"] = (
-                config["overwrite_if_no_pk"].lower() == "true"
-            )
+
+        bool_keys = (
+            "validate_records",
+            "overwrite_if_no_pk",
+            "auto_cast_timestamps",
+            "fallback_on_insert_error",
+            "fallback_include_payload",
+            "advance_state_on_fallback",
+            "sanitize_timezones",
+            "dates_to_varchar",
+        )
+        for key in bool_keys:
+            if key in config and isinstance(config[key], str):
+                config[key] = config[key].lower() == "true"
+
+        if "sanitize_timezones" not in config:
+            config["sanitize_timezones"] = config.get("auto_cast_timestamps", False)
         return config
 
     config_jsonschema = th.PropertiesList(
@@ -173,6 +199,91 @@ class Targetducklake(Target):
             default=10000,
             title="Max Batch Size",
             description="Maximum number of records to process in a single batch",
+        ),
+        th.Property(
+            "fallback_on_insert_error",
+            th.BooleanType(),
+            default=False,
+            title="Quarantine Failed Batches",
+            description=(
+                "When True, batches that fail during insert/merge are written to a fallback"
+                " directory for later replay instead of immediately failing."
+            ),
+        ),
+        th.Property(
+            "fallback_dir",
+            th.StringType(),
+            title="Fallback Directory",
+            description=(
+                "Directory where quarantined batches are written when fallback_on_insert_error"
+                " is enabled. Defaults to <data_path>/_failed_batches/."
+            ),
+        ),
+        th.Property(
+            "fallback_include_payload",
+            th.BooleanType(),
+            default=True,
+            title="Include Raw Payload in Fallback",
+            description=(
+                "When True, also write the raw Singer RECORD payloads as records.jsonl in the"
+                " fallback directory."
+            ),
+        ),
+        th.Property(
+            "advance_state_on_fallback",
+            th.BooleanType(),
+            default=False,
+            title="Advance State After Fallback",
+            description=(
+                "When True, the target continues processing and advances state after writing a"
+                " quarantined batch. When False, the original error is raised to halt the run."
+            ),
+        ),
+        th.Property(
+            "sanitize_timezones",
+            th.BooleanType(),
+            title="Sanitize Timezones",
+            description=(
+                "Normalize timezone-aware values and UTC±HH:MM strings to UTC-naive timestamps"
+                " prior to Arrow ingestion. Defaults to the value of auto_cast_timestamps."
+            ),
+        ),
+        th.Property(
+            "dates_to_varchar",
+            th.BooleanType(),
+            default=False,
+            title="Coerce Dates to VARCHAR",
+            description=(
+                "When True, timestamp-like columns are coerced to VARCHAR prior to ingestion"
+                " to avoid timezone and format errors."
+            ),
+        ),
+        th.Property(
+            "dates_to_varchar_streams",
+            th.ArrayType(th.StringType()),
+            title="Streams for Dates→VARCHAR",
+            description=(
+                "List of stream names whose timestamp-like columns should be coerced to"
+                " VARCHAR when dates_to_varchar is enabled."
+            ),
+        ),
+        th.Property(
+            "dates_to_varchar_columns",
+            th.ObjectType(additional_properties=th.ArrayType(th.StringType())),
+            title="Specific Columns for Dates→VARCHAR",
+            description=(
+                "Mapping of stream name to specific column names that should be coerced to"
+                " VARCHAR."
+            ),
+        ),
+        th.Property(
+            "dates_to_varchar_glob",
+            th.ArrayType(th.StringType()),
+            title="Column Patterns for Dates→VARCHAR",
+            description=(
+                "List of glob patterns applied to column names across all streams to mark"
+                " columns that should be coerced to VARCHAR."
+            ),
         ),
         th.Property(
             "partition_fields",

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import json
+from datetime import datetime, timezone
 from decimal import Decimal
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 from singer_sdk.exceptions import ConfigValidationError
 
@@ -104,6 +108,11 @@ class TestTargetducklakeConfig:
         assert target.config["temp_file_dir"] == "temp_files/"
         assert target.config["max_batch_size"] == 10000
         assert target.config["auto_cast_timestamps"] == False
+        assert target.config["sanitize_timezones"] == False
+        assert target.config["fallback_on_insert_error"] == False
+        assert target.config["fallback_include_payload"] == True
+        assert target.config["advance_state_on_fallback"] == False
+        assert target.config["dates_to_varchar"] == False
 
     def test_partition_fields_config(self):
         """Test partition fields configuration."""
@@ -123,6 +132,32 @@ class TestTargetducklakeConfig:
         }
         target = Targetducklake(config=config)
         assert "users" in target.config["partition_fields"]
+
+    def test_sanitize_timezones_tracks_auto_cast(self):
+        """Sanitize timezones defaults to auto_cast_timestamps when unset."""
+        config = {
+            "catalog_url": "test.db",
+            "data_path": "/tmp/test",
+            "storage_type": "local",
+            "auto_cast_timestamps": True,
+        }
+        target = Targetducklake(config=config)
+        assert target.config["sanitize_timezones"] is True
+
+    def test_dates_to_varchar_literal_parsing(self):
+        """Literal parsing converts string inputs to Python collections."""
+        config = {
+            "catalog_url": "test.db",
+            "data_path": "/tmp/test",
+            "storage_type": "local",
+            "dates_to_varchar_streams": "['users']",
+            "dates_to_varchar_columns": "{'users': ['created_at']}",
+            "dates_to_varchar_glob": "['*_time']",
+        }
+        target = Targetducklake(config=config)
+        assert target.config["dates_to_varchar_streams"] == ["users"]
+        assert target.config["dates_to_varchar_columns"] == {"users": ["created_at"]}
+        assert target.config["dates_to_varchar_glob"] == ["*_time"]
 
 
 class TestDuckLakeConnector:
@@ -268,6 +303,141 @@ class TestDucklakeSink:
                     key_properties=None,
                 )
                 # This would test the actual target_schema property
+
+    def test_dates_to_varchar_coercion(self, mock_target):
+        """Dates-to-VARCHAR configuration coerces schema and values."""
+        mock_target.config.update({
+            "dates_to_varchar": True,
+            "temp_file_dir": "temp_files/",
+        })
+        schema = {
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "created_at": {"type": "string", "format": "date-time"},
+            },
+        }
+
+        with patch("target_ducklake.sinks.DuckLakeConnector") as connector_cls:
+            connector = connector_cls.return_value
+            connector.json_to_ducklake_schema.return_value = [
+                {"name": "id", "type": "INTEGER"},
+                {"name": "created_at", "type": "STRING"},
+            ]
+            sink = ducklakeSink(
+                target=mock_target,
+                stream_name="users",
+                schema=schema,
+                key_properties=None,
+            )
+
+        assert "created_at" in sink._varchar_columns
+        assert (
+            "target_ducklake_dates_to_varchar_columns_total",
+            {"stream": "users"},
+        ) in sink._emitted_metrics
+
+        records = [{"id": 1, "created_at": datetime(2024, 1, 1, tzinfo=timezone.utc)}]
+        sink._coerce_records_to_varchar(records)
+        assert isinstance(records[0]["created_at"], str)
+
+    def test_timezone_sanitization(self, mock_target):
+        """Timezone sanitization normalizes UTC± offsets."""
+        mock_target.config.update({
+            "sanitize_timezones": True,
+        })
+        schema = {
+            "type": "object",
+            "properties": {
+                "created_at": {"type": "string"},
+            },
+        }
+
+        with patch("target_ducklake.sinks.DuckLakeConnector") as connector_cls:
+            connector = connector_cls.return_value
+            connector.json_to_ducklake_schema.return_value = [
+                {"name": "created_at", "type": "STRING"},
+            ]
+            sink = ducklakeSink(
+                target=mock_target,
+                stream_name="users",
+                schema=schema,
+                key_properties=None,
+            )
+
+        value = sink._sanitize_value("2025-10-04T12:00:00 UTC-08:00", "created_at")
+        assert value == "2025-10-04T20:00:00"
+        assert sink._tz_warning_emitted is True
+
+    def test_process_batch_quarantine_on_failure(self, mock_target, tmp_path):
+        """Failed batches are quarantined when fallback is enabled."""
+        fallback_dir = tmp_path / "fallback"
+        temp_dir = tmp_path / "temp"
+        mock_target.config.update(
+            {
+                "fallback_on_insert_error": True,
+                "fallback_dir": str(fallback_dir),
+                "fallback_include_payload": True,
+                "temp_file_dir": str(temp_dir),
+                "sanitize_timezones": True,
+            }
+        )
+        schema = {
+            "type": "object",
+            "properties": {
+                "id": {"type": "integer"},
+                "created_at": {"type": "string", "format": "date-time"},
+            },
+        }
+
+        with patch("target_ducklake.sinks.DuckLakeConnector") as connector_cls:
+            connector = connector_cls.return_value
+            connector.json_to_ducklake_schema.return_value = [
+                {"name": "id", "type": "INTEGER"},
+                {"name": "created_at", "type": "STRING"},
+            ]
+            connector.get_table_columns.return_value = ["id", "created_at"]
+            connector.insert_into_table.side_effect = RuntimeError("boom")
+            sink = ducklakeSink(
+                target=mock_target,
+                stream_name="users",
+                schema=schema,
+                key_properties=None,
+            )
+
+        context = {
+            "records": [
+                {"id": 1, "created_at": "2025-10-04T12:00:00 UTC-08:00"},
+            ]
+        }
+
+        with pytest.raises(RuntimeError):
+            sink.process_batch(context)
+
+        quarantine_dirs = list(Path(fallback_dir, "users").glob("*"))
+        assert len(quarantine_dirs) == 1
+        batch_dir = quarantine_dirs[0]
+        parquet_path = batch_dir / "batch.parquet"
+        meta_path = batch_dir / "meta.json"
+        records_path = batch_dir / "records.jsonl"
+
+        assert parquet_path.exists()
+        assert meta_path.exists()
+        assert records_path.exists()
+
+        table = pq.read_table(parquet_path)
+        assert table.column("created_at").to_pylist()[0] == "2025-10-04T20:00:00"
+
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        assert meta["error"]["type"] == "RuntimeError"
+        assert meta["settings"]["fallback_on_insert_error"] is True
+
+        records = [json.loads(line) for line in records_path.read_text(encoding="utf-8").splitlines()]
+        assert records[0]["created_at"] == "2025-10-04T12:00:00 UTC-08:00"
+        assert (
+            "target_ducklake_fallback_batches_total",
+            {"stream": "users"},
+        ) in sink._emitted_metrics
 
 
 class TestFlattenModule:


### PR DESCRIPTION
## Summary
- add configuration parsing and schema definitions for batch fallback, timezone sanitization, and dates-to-varchar overrides
- implement sink fallback handling that sanitizes timestamps, coerces configured columns to VARCHAR, and writes quarantine artifacts with metrics
- extend tests and documentation to cover the new sanitization, fallback replay, and Meltano settings

## Testing
- uv run pytest -q *(fails: unable to download pyarrow from PyPI in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68e181eea1a483299e75c84df36fce96