### PR TITLE
feat: Truncation logic for > 63 character column names

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Key files:
 - `target_ducklake/target.py` — `Targetducklake(SQLTarget)`: config parsing, entry point
 - `target_ducklake/sinks.py` — `ducklakeSink(SQLSink)`: record processing, batching, parquet temp files, load methods (append/merge/overwrite)
 - `target_ducklake/connector.py` — `DuckLakeConnector(SQLConnector)`: DuckDB connection, DDL, insert/merge operations, centralized retry logic in `execute()`
-- `target_ducklake/flatten.py` — Schema/record flattening, auto-timestamp casting
+- `target_ducklake/flatten.py` — Schema/record flattening, auto-timestamp casting, column name truncation
 - `target_ducklake/parquet_utils.py` — PyArrow schema conversion, datetime normalization
 - `target_ducklake/logger.py` — Logging config
 
@@ -65,6 +65,16 @@ All queries go through `DuckLakeConnector.execute()`, which retries on `duckdb.I
 - **DML safety:** `insert_into_table` and `merge_into_table` wrap operations in `BEGIN TRANSACTION` / `COMMIT`, so failed attempts are rolled back before retry
 - **No reconnect needed:** On retry, we do NOT need to DETACH + re-ATTACH the DuckLake catalog. The DuckDB `postgres` extension uses a connection pool (`PostgresConnectionPool`) that calls `PQreset()` on bad connections when they are returned to the pool. After a failed query, the next retry gets a repaired or fresh Postgres connection automatically. See: [postgres_connection_pool.cpp#L93-L99](https://github.com/duckdb/duckdb-postgres/blob/main/src/storage/postgres_connection_pool.cpp#L93-L99)
 - **`ducklake_max_retry_count` does NOT cover connectivity errors.** DuckLake's internal retry loop only retries concurrency conflicts (primary key/unique violations, conflict errors) during transaction commit. Postgres "Connection refused" errors are NOT retried by DuckLake — our `execute()` retry is the only layer handling these. See: [ducklake_transaction.cpp#L2518-L2531](https://github.com/duckdb/ducklake/blob/main/src/storage/ducklake_transaction.cpp#L2518-L2531)
+
+## Column Name Truncation
+
+When `catalog_type` is `postgres`, column names longer than 63 characters are automatically truncated to match PostgreSQL's identifier length limit (NAMEDATALEN). This is a workaround for [ducklake#619](https://github.com/duckdb/ducklake/issues/619).
+
+- Controlled by `max_column_length` config (default 63, set to 0 to disable)
+- Only applies when `catalog_type == "postgres"`
+- Collision handling: if truncation produces duplicate names, columns are shortened further and given `_{i}` suffixes
+- Implementation: `truncate_column_names()` in `flatten.py`, called via `ducklakeSink._apply_column_name_truncation()` in `sinks.py`
+- The truncation mapping is also applied to `key_properties` and to each record in `process_record()`
 
 ## Key Dependencies
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Supports append, merge, and overwrite load methods (default is merge). The load 
 | `convert_tz_to_utc` | boolean | ❌ | `false` | When True, automatically converts timezone of timestamp-like fields to UTC |
 | `validate_records` | boolean | ❌ | `false` | Whether to validate the schema of the incoming streams |
 | `overwrite_if_no_pk` | boolean | ❌ | `false` | When True, truncates the target table before inserting records if no primary keys are defined in the stream. Overrides load_method. |
+| `max_column_length` | integer | ❌ | `63` | Maximum length for column names. Only applied when `catalog_type` is `postgres`. Names exceeding this limit are truncated. Colliding truncated names get a `_{i}` suffix. Set to `0` to disable. See [ducklake#619](https://github.com/duckdb/ducklake/issues/619). |
 
 ### Example Meltano YAML Configuration
 

--- a/target_ducklake/connector.py
+++ b/target_ducklake/connector.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import math
 import time
-from typing import Any, Dict, Optional
+from typing import Any
 
 import duckdb
 from singer_sdk.connectors import SQLConnector
@@ -67,7 +67,7 @@ class JSONSchemaToDuckLake(JSONSchemaToSQL):
 class DuckLakeConnector(SQLConnector):
     """Handles DuckLake database connections and setup."""
 
-    def __init__(self, config: Dict[str, Any]) -> None:
+    def __init__(self, config: dict[str, Any]) -> None:
         """Initialize the DuckLake connector with configuration.
 
         Args:
@@ -463,7 +463,7 @@ class DuckLakeConnector(SQLConnector):
         file_columns: list[str],
         target_table_columns: list[str],
         key_properties: list[str],
-        date_type_keys: list[Optional[str]] = [],
+        date_type_keys: list[str | None] = [],
     ):
         """Merge data from a parquet file into the table using DELETE+INSERT.
 

--- a/target_ducklake/flatten.py
+++ b/target_ducklake/flatten.py
@@ -178,6 +178,52 @@ def flatten_schema(
     return dict(sorted_items)
 
 
+def truncate_column_names(
+    schema: dict, max_length: int = 63
+) -> tuple[dict, dict[str, str]]:
+    """Truncate schema column names to max_length, resolving collisions.
+
+    PostgreSQL truncates identifiers to 63 characters (NAMEDATALEN).
+    This function applies the same truncation to avoid DuckLake binder errors
+    when using a Postgres catalog.
+
+    Returns (new_schema, old_to_new_name_mapping).
+    The mapping only includes names that actually changed.
+
+    Collision resolution: when multiple columns map to the same truncated name,
+    each is shortened further and given a ``_{i}`` suffix (0-indexed).
+    """
+    if max_length <= 0:
+        return schema, {}
+
+    # First pass: truncate names that exceed max_length
+    truncated: dict[str, str] = {}
+    for name in schema:
+        truncated[name] = name[:max_length] if len(name) > max_length else name
+
+    # Detect collisions
+    seen: dict[str, list[str]] = {}
+    for original, trunc in truncated.items():
+        seen.setdefault(trunc, []).append(original)
+
+    # Resolve collisions with _{i} suffixes
+    mapping: dict[str, str] = {}
+    for trunc, originals in seen.items():
+        if len(originals) == 1:
+            original = originals[0]
+            if trunc != original:
+                mapping[original] = trunc
+        else:
+            for i, original in enumerate(originals):
+                suffix = f"_{i}"
+                new_name = trunc[: max_length - len(suffix)] + suffix
+                mapping[original] = new_name
+
+    # Build new schema preserving insertion order
+    new_schema = {mapping.get(name, name): value for name, value in schema.items()}
+    return new_schema, mapping
+
+
 # pylint: disable=redefined-outer-name
 def _should_json_dump_value(key, value, flatten_schema=None):
     """Adapted from here: https://github.com/jwills/target-duckdb/blob/36c8ce68a0b2584c4bbb07325482968b1edc0c40/target_duckdb/db_sync.py#L125

--- a/target_ducklake/sinks.py
+++ b/target_ducklake/sinks.py
@@ -16,7 +16,11 @@ from singer_sdk import Target
 from singer_sdk.sinks import SQLSink
 
 from target_ducklake.connector import DuckLakeConnector
-from target_ducklake.flatten import flatten_record, flatten_schema
+from target_ducklake.flatten import (
+    flatten_record,
+    flatten_schema,
+    truncate_column_names,
+)
 from target_ducklake.parquet_utils import (
     concat_tables,
     flatten_schema_to_pyarrow_schema,
@@ -63,6 +67,10 @@ class ducklakeSink(SQLSink):
         self.logger.info(
             f"Flattened schema for stream '{stream_name}': {self.flatten_schema}"
         )
+
+        self._column_name_mapping: dict[str, str] = {}
+        self._apply_column_name_truncation()
+
         self.pyarrow_schema = flatten_schema_to_pyarrow_schema(self.flatten_schema)
         self.ducklake_schema = self.connector.json_to_ducklake_schema(
             self.flatten_schema
@@ -147,6 +155,37 @@ class ducklakeSink(SQLSink):
         """
         return self.config.get("max_batch_size", 10000)
 
+    def _apply_column_name_truncation(self) -> None:
+        """Truncate column names for Postgres catalog compatibility.
+
+        PostgreSQL silently truncates identifiers to 63 characters (NAMEDATALEN),
+        which causes DuckLake binder errors. This method applies the same truncation
+        upfront so all downstream schemas and records use consistent names.
+        See: https://github.com/duckdb/ducklake/issues/619
+        """
+        if self.config.get("catalog_type", "postgres") != "postgres":
+            return
+
+        max_col_length = self.config.get("max_column_length", 63)
+        if max_col_length <= 0:
+            return
+
+        self.flatten_schema, self._column_name_mapping = truncate_column_names(
+            self.flatten_schema, max_length=max_col_length
+        )
+        if self._column_name_mapping:
+            self.logger.info(
+                f"Truncated {len(self._column_name_mapping)} column name(s) "
+                f"to max length {max_col_length}: {self._column_name_mapping}"
+            )
+
+        # Uses _key_properties (the backing attribute) because key_properties is a
+        # read-only property on the parent SQLSink class with no setter.
+        if self._key_properties and self._column_name_mapping:
+            self._key_properties = [
+                self._column_name_mapping.get(kp, kp) for kp in self._key_properties
+            ]
+
     def setup(self) -> None:
         # create the target schema if it doesn't exist
         self.connector.prepare_target_schema(target_schema_name=self.target_schema)
@@ -181,6 +220,12 @@ class ducklakeSink(SQLSink):
             flatten_schema=self.flatten_schema,
             max_level=self.flatten_max_level,
         )
+        # Apply column name truncation mapping
+        if self._column_name_mapping:
+            record_flatten = {
+                self._column_name_mapping.get(k, k): v
+                for k, v in record_flatten.items()
+            }
         super().process_record(record_flatten, context)
 
     def _remove_temp_table_duplicates(self, pyarrow_df):

--- a/target_ducklake/target.py
+++ b/target_ducklake/target.py
@@ -41,6 +41,8 @@ class Targetducklake(SQLTarget):
             config["max_batch_size"] = int(config.get("max_batch_size", 10000))
         if "flatten_max_level" in config:
             config["flatten_max_level"] = int(config.get("flatten_max_level", 0))
+        if "max_column_length" in config:
+            config["max_column_length"] = int(config.get("max_column_length", 63))
         if "validate_records" in config and isinstance(config["validate_records"], str):
             config["validate_records"] = config["validate_records"].lower() == "true"
         if "overwrite_if_no_pk" in config and isinstance(
@@ -227,6 +229,20 @@ class Targetducklake(SQLTarget):
                 "Object mapping stream names to arrays of partition column definitions. "
                 "Each stream key maps directly to an array of column definitions. "
                 "Can be provided as a JSON string or object."
+            ),
+        ),
+        th.Property(
+            "max_column_length",
+            th.CustomType(
+                {"oneOf": [{"type": "string"}, {"type": "integer", "minimum": 0}]}
+            ),
+            default=63,
+            title="Max Column Name Length",
+            description=(
+                "Maximum length for column names. Only applied when catalog_type is 'postgres'. "
+                "Names exceeding this limit are truncated to avoid PostgreSQL's 63-character "
+                "identifier limit (NAMEDATALEN). Colliding truncated names get a _{i} suffix. "
+                "Set to 0 to disable truncation."
             ),
         ),
         th.Property(

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -21,6 +21,7 @@ from target_ducklake.flatten import (
     _should_auto_cast_to_timestamp,
     flatten_record,
     flatten_schema,
+    truncate_column_names,
 )
 from target_ducklake.parquet_utils import (
     _field_type_to_pyarrow_field,
@@ -614,3 +615,110 @@ class TestExecuteRetry:
 
         assert mock_cursor.execute.call_count == 1
         mock_sleep.assert_not_called()
+
+
+class TestTruncateColumnNames:
+    """Test column name truncation for Postgres compatibility."""
+
+    def test_no_truncation_needed(self):
+        """Names within limit are unchanged, mapping is empty."""
+        schema = {"id": {"type": "integer"}, "name": {"type": "string"}}
+        new_schema, mapping = truncate_column_names(schema, max_length=63)
+        assert new_schema == schema
+        assert mapping == {}
+
+    def test_simple_truncation(self):
+        """A single long name is truncated to max_length."""
+        long_name = "a" * 80
+        schema = {long_name: {"type": "string"}, "id": {"type": "integer"}}
+        new_schema, mapping = truncate_column_names(schema, max_length=63)
+
+        assert long_name not in new_schema
+        truncated = "a" * 63
+        assert truncated in new_schema
+        assert mapping == {long_name: truncated}
+        # Schema values are preserved
+        assert new_schema[truncated] == {"type": "string"}
+        assert new_schema["id"] == {"type": "integer"}
+
+    def test_collision_resolution(self):
+        """Two names that truncate to the same string get _{i} suffixes."""
+        prefix = "a" * 63
+        name_a = prefix + "_suffix_one"
+        name_b = prefix + "_suffix_two"
+        schema = {name_a: {"type": "string"}, name_b: {"type": "integer"}}
+        new_schema, mapping = truncate_column_names(schema, max_length=63)
+
+        # Both should be in the new schema with different names
+        assert len(new_schema) == 2
+        values = list(new_schema.keys())
+        assert values[0] != values[1]
+        # Each should end with _0 or _1
+        assert values[0].endswith("_0")
+        assert values[1].endswith("_1")
+        # Total length should not exceed max_length
+        assert all(len(v) <= 63 for v in values)
+
+    def test_disabled_with_zero(self):
+        """max_length=0 disables truncation."""
+        long_name = "a" * 100
+        schema = {long_name: {"type": "string"}}
+        new_schema, mapping = truncate_column_names(schema, max_length=0)
+        assert new_schema == schema
+        assert mapping == {}
+
+    def test_postgres_only_in_sink(self):
+        """Truncation is skipped for non-postgres catalog types."""
+        long_name = "a" * 80
+        schema = {
+            "type": "object",
+            "properties": {long_name: {"type": "string"}},
+        }
+        config = {
+            "catalog_url": "test.db",
+            "data_path": "/tmp/test",
+            "storage_type": "local",
+            "catalog_type": "duckdb",
+        }
+        with patch("target_ducklake.sinks.DuckLakeConnector"):
+            target = Mock()
+            target.config = config
+            sink = ducklakeSink(
+                target=target,
+                stream_name="test-table",
+                schema=schema,
+                key_properties=None,
+            )
+            # Column name should NOT be truncated for duckdb catalog
+            assert sink._column_name_mapping == {}
+            assert long_name in sink.flatten_schema
+
+    def test_key_properties_truncated(self):
+        """Key properties are updated when their column name is truncated."""
+        long_key = "a" * 80
+        schema = {
+            "type": "object",
+            "properties": {
+                long_key: {"type": "integer"},
+                "name": {"type": "string"},
+            },
+        }
+        config = {
+            "catalog_url": "test.db",
+            "data_path": "/tmp/test",
+            "storage_type": "local",
+            "catalog_type": "postgres",
+        }
+        with patch("target_ducklake.sinks.DuckLakeConnector"):
+            target = Mock()
+            target.config = config
+            sink = ducklakeSink(
+                target=target,
+                stream_name="test-table",
+                schema=schema,
+                key_properties=[long_key],
+            )
+            # Key property should be truncated
+            assert sink.key_properties == ["a" * 63]
+            assert long_key not in sink.flatten_schema
+            assert "a" * 63 in sink.flatten_schema


### PR DESCRIPTION
Postgres catalog have limitation of 63 character length for column names: https://github.com/duckdb/ducklake/issues/619

Columns > 63 characters will be truncated to 63 characters. In the case of collisions, columns will be suffixed with "_{i}"