### PR TITLE
fix: call get_table_columns once 

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,24 @@ When `catalog_type` is `postgres`, column names longer than 63 characters are au
 - Implementation: `truncate_column_names()` in `flatten.py`, called via `ducklakeSink._apply_column_name_truncation()` in `sinks.py`
 - The truncation mapping is also applied to `key_properties` and to each record in `process_record()`
 
+## GCS Authentication (Definite-specific)
+
+When `storage_type` is `GCS`, the connector supports two authentication modes:
+
+| HMAC keys provided? | Behavior |
+|---|---|
+| Both `public_key` + `secret_key` set | **Legacy path** — public ducklake extension + `TYPE gcs` HMAC secret |
+| Neither set | **ADC path** — Definite-hosted ducklake/gcs extensions + `TYPE GCP, PROVIDER credential_chain` secret (uses GKE service account) |
+
+The ADC path (`_use_definite_gcp_credential_chain()`) exists because Definite stopped provisioning HMAC keys for new DuckLake integrations (2026-04-08). Key details:
+
+- Extensions are installed from `DEFINITE_EXTENSION_REPO` (`https://storage.googleapis.com/def-duckdb-extensions`) — the public httpfs-based ducklake doesn't support `TYPE GCP` secrets
+- `allow_unsigned_extensions` is enabled on the DuckDB connection for the Definite-hosted builds
+- Data paths are rewritten from `gs://` to `gcss://` (required by the native `gcs` extension)
+- Mirrors the canonical pattern from defapi `integration_config.py:135-146`
+- Implementation: `_build_gcp_credential_chain_script()` in `connector.py`, with shared `_build_attach_statement()` for the ATTACH logic
+- S3 and local storage paths are completely unchanged
+
 ## Key Dependencies
 
-- `duckdb~=1.4.0`, `singer-sdk~=0.46.4`, `pyarrow>=20.0.0`, `polars>=1.31.0`, `sqlalchemy>=2.0.41`
+- `duckdb==1.5.1`, `singer-sdk~=0.46.4`, `pyarrow>=20.0.0`, `polars>=1.31.0`, `sqlalchemy>=2.0.41`

--- a/target_ducklake/sinks.py
+++ b/target_ducklake/sinks.py
@@ -191,7 +191,7 @@ class ducklakeSink(SQLSink):
         self.connector.prepare_target_schema(target_schema_name=self.target_schema)
 
         # prepare the table
-        self.connector.prepare_table(
+        self._table_columns = self.connector.prepare_table(
             target_schema_name=self.target_schema,
             table_name=self.target_table,
             columns=self.ducklake_schema,
@@ -350,9 +350,7 @@ class ducklakeSink(SQLSink):
 
         # get the columns from the file and the table
         file_columns = [col["name"] for col in self.ducklake_schema]
-        table_columns = self.connector.get_table_columns(
-            self.target_schema, self.target_table
-        )
+        table_columns = self._table_columns
 
         # If no key properties, load method is append or overwrite, or table should be overwritten
         # we simply insert the data. Table is already truncated in setup if load method is overwrite


### PR DESCRIPTION
Reuse the table column list from prepare_table method. Reduces database fetches.