### PR TITLE
fix: restore pg_pool_max_connections to 64 (regression in duckdb 1.5.2)

### DIFF
--- a/target_ducklake/connector.py
+++ b/target_ducklake/connector.py
@@ -244,6 +244,8 @@ class DuckLakeConnector(SQLConnector):
             "LOAD gcs;",
             "LOAD ducklake;",
             "SET ducklake_max_retry_count=100;",
+            # Restore pre-1.5.2 default (duckdb-postgres #427 dropped it to max(num_cpus, 8))
+            "SET pg_pool_max_connections=64;",
             self._build_attach_statement(data_path=data_path),
             (
                 "CREATE SECRET ("
@@ -264,6 +266,8 @@ class DuckLakeConnector(SQLConnector):
             "INSTALL ducklake;",
             "INSTALL postgres;",
             "SET ducklake_max_retry_count=100;",
+            # Restore pre-1.5.2 default (duckdb-postgres #427 dropped it to max(num_cpus, 8))
+            "SET pg_pool_max_connections=64;",
         ]
 
         script_parts.append(self._build_attach_statement())


### PR DESCRIPTION
## Summary

Connection pool timeout errors (\`_duckdb.Error: Connection pool timeout: all 16 connections in use, waited 30000ms\`) have been firing across meltano (and a handful of dlt) syncs since **2026-04-15 13:44 UTC** — exactly when this repo bumped to duckdb 1.5.2 (#55).

Root cause: [duckdb-postgres #427](https://github.com/duckdb/duckdb-postgres/pull/427) (merged Apr 3, shipped in duckdb 1.5.2 on Apr 13) replaced the connection pool implementation. From the PR:

> default pool size is changed from \`64\` to \`max(num_cpus, 8)\`

On our 16-vCPU \`ek-standard-16\` meltano-workers nodes that means a per-process catalog pool of **16** instead of **64**. Concurrent stream draining + DuckLake snapshot queries exhaust 16 connections quickly (we observed pool sizes of 8, 16, and 32 in error logs, matching node CPU counts).

This fix sets \`pg_pool_max_connections=64\` in both startup script paths (Definite GCP credential-chain path and the legacy/HMAC/S3 path), restoring the pre-1.5.2 default.

## Future cleanup

Upstream is still iterating on the new pool. Worth re-evaluating this SET when we bump duckdb past these patches:

- [duckdb-postgres #452](https://github.com/duckdb/duckdb-postgres/pull/452) (merged Apr 29) changes defaults to \`acquire_mode: force\` (always connect, ignore pool limit) and raises the cap to \`cpu_count * 1.5 ≤ 32\`. With \`acquire_mode: force\` as the default, pool exhaustion becomes non-blocking — likely makes this SET unnecessary.
- [duckdb-postgres #455](https://github.com/duckdb/duckdb-postgres/pull/455) (merged Apr 29) fixes the default value of \`pg_pool_max_connections\`.

Once a duckdb release containing #452/#455 lands and we upgrade, **delete this SET** and confirm the timeout errors don't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)