### PR TITLE
fix: LOAD postgres before SET pg_pool_max_connections

### DIFF
--- a/target_ducklake/connector.py
+++ b/target_ducklake/connector.py
@@ -243,6 +243,7 @@ class DuckLakeConnector(SQLConnector):
             "LOAD httpfs;",
             "LOAD gcs;",
             "LOAD ducklake;",
+            "LOAD postgres;",
             "SET ducklake_max_retry_count=100;",
             # Restore pre-1.5.2 default (duckdb-postgres #427 dropped it to max(num_cpus, 8))
             "SET pg_pool_max_connections=64;",
@@ -265,6 +266,7 @@ class DuckLakeConnector(SQLConnector):
         script_parts = [
             "INSTALL ducklake;",
             "INSTALL postgres;",
+            "LOAD postgres;",
             "SET ducklake_max_retry_count=100;",
             # Restore pre-1.5.2 default (duckdb-postgres #427 dropped it to max(num_cpus, 8))
             "SET pg_pool_max_connections=64;",


### PR DESCRIPTION
## Summary

Follow-up to #58. The \`SET pg_pool_max_connections=64\` from #58 was silently a no-op because the postgres extension hadn't been LOADed yet — extension options are only registered in the system catalog at LOAD time. ATTACH would auto-load it later, but by then the SET had already been ignored, so pools kept being created at the default \`max(num_cpus, 8)\` (= 16 on our \`ek-standard-16\` workers).

Verified post-#58: error logs still show \`Connection pool timeout: all 16 connections in use\` despite the SET being present in the deployed connector.py.

This PR adds \`LOAD postgres;\` before the SET in both startup script paths (Definite GCP credential-chain path and legacy/HMAC path) so the option is registered when the SET runs.

## Future cleanup

Same as #58 — once a duckdb release containing [duckdb-postgres #452](https://github.com/duckdb/duckdb-postgres/pull/452) and [#455](https://github.com/duckdb/duckdb-postgres/pull/455) lands and we upgrade, both this LOAD line and the SET can be removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)