### PR TITLE
Coerce epoch-numeric values into ISO strings for date-time fields

### DIFF
--- a/target_ducklake/flatten.py
+++ b/target_ducklake/flatten.py
@@ -54,12 +54,16 @@ def _should_auto_cast_to_timestamp(
     if column_name.lower() not in TIMESTAMP_COLUMN_NAMES:
         return False
 
-    # Check if it's a string type (either single string or list containing string)
+    # String fields are the obvious case (ISO datetimes), but many taps
+    # (notably tap-mixpanel) declare event-time columns as integer/number
+    # epochs. We coerce values to ISO at record-preprocess time, so it is
+    # safe to mark them as date-time here.
+    allowed = {"string", "integer", "number"}
     entry_type = schema_entry.get("type", [])
     if isinstance(entry_type, str):
-        return entry_type == "string"
+        return entry_type in allowed
     if isinstance(entry_type, list):
-        return "string" in entry_type
+        return any(t in allowed for t in entry_type)
 
     return False
 

--- a/target_ducklake/sinks.py
+++ b/target_ducklake/sinks.py
@@ -25,6 +25,7 @@ from target_ducklake.parquet_utils import (
     concat_tables,
     flatten_schema_to_pyarrow_schema,
 )
+from target_ducklake.timestamp_coerce import coerce_timestamp_value
 
 
 class ducklakeSink(SQLSink):
@@ -70,6 +71,15 @@ class ducklakeSink(SQLSink):
 
         self._column_name_mapping: dict[str, str] = {}
         self._apply_column_name_truncation()
+
+        # Cache the set of date-time fields. We coerce numeric-epoch values on
+        # these in process_record so DuckLake doesn't try to cast bigints into
+        # TIMESTAMP and overflow.
+        self._datetime_fields: frozenset[str] = frozenset(
+            name
+            for name, entry in self.flatten_schema.items()
+            if isinstance(entry, dict) and entry.get("format") == "date-time"
+        )
 
         self.pyarrow_schema = flatten_schema_to_pyarrow_schema(self.flatten_schema)
         self.ducklake_schema = self.connector.json_to_ducklake_schema(
@@ -226,6 +236,12 @@ class ducklakeSink(SQLSink):
                 self._column_name_mapping.get(k, k): v
                 for k, v in record_flatten.items()
             }
+        # Coerce numeric epoch values in date-time fields (e.g. tap-mixpanel
+        # emits event time as integer ms even when schema says date-time).
+        if self._datetime_fields:
+            for k in self._datetime_fields:
+                if k in record_flatten:
+                    record_flatten[k] = coerce_timestamp_value(record_flatten[k])
         super().process_record(record_flatten, context)
 
     def _remove_temp_table_duplicates(self, pyarrow_df):

--- a/target_ducklake/timestamp_coerce.py
+++ b/target_ducklake/timestamp_coerce.py
@@ -1,0 +1,73 @@
+"""Coerce epoch-numeric values into ISO datetime strings for date-time fields.
+
+Some taps (notably tap-mixpanel `export`) declare a column as
+``{"type": ["null", "string"], "format": "date-time"}`` but emit the value
+as an integer Unix epoch in milliseconds. DuckLake then fails on INSERT
+because it tries to cast the bigint as a seconds-epoch and overflows the
+TIMESTAMP range.
+
+This helper detects numeric epoch values (int, float, or all-digit string),
+distinguishes seconds vs milliseconds vs microseconds by magnitude, and
+returns an ISO 8601 UTC string that DuckLake parses cleanly. ISO strings
+and ``datetime`` instances pass through unchanged.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+# Magnitude thresholds for the unit guess. 1e11 seconds is year 5138, so any
+# absolute epoch >= 1e11 is unambiguously sub-second; 1e14 is the microsecond
+# boundary. Values below 1e11 are treated as seconds, which covers the full
+# realistic past + ~1000 years into the future.
+_MS_THRESHOLD = 1e11
+_US_THRESHOLD = 1e14
+
+
+def _is_numeric_string(value: str) -> bool:
+    s = value.strip()
+    if not s:
+        return False
+    if s[0] in "+-":
+        s = s[1:]
+    if not s:
+        return False
+    # Accept a single decimal point.
+    return s.replace(".", "", 1).isdigit()
+
+
+def coerce_timestamp_value(value):
+    """Return an ISO datetime string if value looks like a numeric epoch.
+
+    Pass-through cases (returned unchanged):
+        - ``None``
+        - ``datetime`` instances
+        - ``bool`` (Python True/False are ints; never treat as timestamps)
+        - non-numeric strings (assumed to be ISO 8601 already)
+        - any other type
+    """
+    if value is None or isinstance(value, datetime):
+        return value
+    if isinstance(value, bool):
+        return value
+
+    if isinstance(value, (int, float)):
+        epoch = float(value)
+    elif isinstance(value, str) and _is_numeric_string(value):
+        try:
+            epoch = float(value)
+        except ValueError:
+            return value
+    else:
+        return value
+
+    abs_epoch = abs(epoch)
+    if abs_epoch >= _US_THRESHOLD:
+        epoch = epoch / 1_000_000.0
+    elif abs_epoch >= _MS_THRESHOLD:
+        epoch = epoch / 1_000.0
+
+    try:
+        return datetime.fromtimestamp(epoch, tz=timezone.utc).isoformat()
+    except (OverflowError, OSError, ValueError):
+        return value

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -365,6 +365,30 @@ class TestFlattenModule:
         assert result["format"] == "date-time"
         assert result["type"] == "string"
 
+    def test_should_auto_cast_to_timestamp_integer_and_number(self):
+        """Auto-cast must also fire on integer/number epochs (e.g. Mixpanel)."""
+        assert (
+            _should_auto_cast_to_timestamp(
+                "timestamp", {"type": "integer"}, auto_cast_timestamps=True
+            )
+            is True
+        )
+        assert (
+            _should_auto_cast_to_timestamp(
+                "created_at",
+                {"type": ["null", "number"]},
+                auto_cast_timestamps=True,
+            )
+            is True
+        )
+        # Non-numeric, non-string types should still be skipped.
+        assert (
+            _should_auto_cast_to_timestamp(
+                "timestamp", {"type": "boolean"}, auto_cast_timestamps=True
+            )
+            is False
+        )
+
 
 class TestParquetUtils:
     """Test parquet utilities functionality."""

--- a/tests/test_timestamp_coerce.py
+++ b/tests/test_timestamp_coerce.py
@@ -1,0 +1,84 @@
+"""Tests for the epoch-to-ISO timestamp coercion helper.
+
+Covers the regression triggered by tap-mixpanel's `export` stream emitting
+event time as an integer Unix epoch in milliseconds. Without coercion,
+DuckLake fails INSERT with:
+
+    Conversion Error: timestamp field value out of range:
+        "1749637592477" when casting from source column timestamp
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from target_ducklake.timestamp_coerce import coerce_timestamp_value
+
+
+class TestCoerceTimestampValue:
+    def test_passthrough_none(self):
+        assert coerce_timestamp_value(None) is None
+
+    def test_passthrough_datetime(self):
+        dt = datetime(2025, 6, 11, 12, 26, 32, tzinfo=timezone.utc)
+        assert coerce_timestamp_value(dt) is dt
+
+    def test_passthrough_iso_string(self):
+        assert (
+            coerce_timestamp_value("2025-06-11T10:26:32Z") == "2025-06-11T10:26:32Z"
+        )
+
+    def test_passthrough_arbitrary_string(self):
+        assert coerce_timestamp_value("not a number") == "not a number"
+
+    def test_passthrough_bool(self):
+        # Python bool is an int subclass; never coerce.
+        assert coerce_timestamp_value(True) is True
+        assert coerce_timestamp_value(False) is False
+
+    def test_int_milliseconds(self):
+        # The actual Saturn / Mixpanel value that broke the sync.
+        result = coerce_timestamp_value(1749637592477)
+        assert result == "2025-06-11T10:26:32.477000+00:00"
+
+    def test_int_seconds(self):
+        # 10-digit seconds-since-epoch.
+        result = coerce_timestamp_value(1749637592)
+        assert result == "2025-06-11T10:26:32+00:00"
+
+    def test_int_microseconds(self):
+        # 16-digit microsecond epoch.
+        result = coerce_timestamp_value(1749637592477000)
+        assert result == "2025-06-11T10:26:32.477000+00:00"
+
+    def test_float_milliseconds(self):
+        result = coerce_timestamp_value(1749637592477.0)
+        assert result == "2025-06-11T10:26:32.477000+00:00"
+
+    def test_numeric_string_milliseconds(self):
+        result = coerce_timestamp_value("1749637592477")
+        assert result == "2025-06-11T10:26:32.477000+00:00"
+
+    def test_numeric_string_with_decimal(self):
+        result = coerce_timestamp_value("1749637592.5")
+        assert result == "2025-06-11T10:26:32.500000+00:00"
+
+    def test_negative_epoch(self):
+        # Pre-1970 timestamp; should still coerce.
+        result = coerce_timestamp_value(-31536000)
+        assert result == "1969-01-01T00:00:00+00:00"
+
+    def test_unparseable_overflow_returns_value_unchanged(self):
+        # Absurdly large value (above us threshold) divided by 1e6 still
+        # blows the platform datetime range on some systems; helper must
+        # not raise.
+        huge = 10**24
+        result = coerce_timestamp_value(huge)
+        # Either coerced or returned unchanged; must not raise.
+        assert result == huge or isinstance(result, str)
+
+    @pytest.mark.parametrize("value", [{}, [], object()])
+    def test_passthrough_unsupported_types(self, value):
+        assert coerce_timestamp_value(value) is value


### PR DESCRIPTION
## Summary
- Saturn's hourly Mixpanel sync into DuckLake has been failing every run since it was created (2026-04-30 13:54 UTC). Every run dies on the first batch of `MIXPANEL.export` and never advances Singer state, so it loops forever.
- Root cause: `tap-mixpanel` (and similar) declare event time as `{"type": ["null","string"], "format": "date-time"}` but emit values as integer Unix epochs in **milliseconds**. DuckLake casts the bigint as seconds and overflows:
  ```
  Conversion Error: timestamp field value out of range:
      "1749637592477" when casting from source column timestamp
  ```
- Fix at the target: coerce numeric epochs on any field where `format == "date-time"` to an ISO 8601 UTC string before parquet write. Magnitude distinguishes seconds vs ms vs us. ISO strings, `datetime` instances, and `None` pass through unchanged.
- Extends `_should_auto_cast_to_timestamp` to also fire on `integer`/`number` schema types — previously it only matched `string`, so taps that emit raw epochs were silently skipped even with `auto_cast_timestamps=true`.

## Files
- `target_ducklake/timestamp_coerce.py` (new): `coerce_timestamp_value` helper.
- `target_ducklake/sinks.py`: caches the set of date-time fields and runs the coercion in `process_record` after flatten + column-name truncation.
- `target_ducklake/flatten.py`: `_should_auto_cast_to_timestamp` accepts integer/number.
- `tests/test_timestamp_coerce.py` (new): 14 cases covering ms/s/us, signed, decimal, ISO passthrough, bool guard, unsupported types.
- `tests/test_comprehensive.py`: extra cases for the auto-cast extension.

## Test plan
- [x] `uv run --python 3.13 pytest` — 65 passed, no regressions.
- [ ] Watch Saturn's next hourly run after merge + release: integration `4f90093f-fbc8-4ca1-ae86-46d50c29d677`, dag `heysaturn.com-mixpanel-to-ducklake-saturn-mixpanel--prod-...`. Singer state may need a manual reset to clear `currently_syncing: export`.
- [ ] Confirm `MIXPANEL.export.timestamp` ends up as a real TIMESTAMP column with sane values.

## Saturn context
- Team `e8f89f57-bb1b-4967-ab13-8638d385e12d`, integration `4f90093f-fbc8-4ca1-ae86-46d50c29d677`, region `EUROPE-WEST2`.
- Pod that surfaced the traceback: `heysaturn-com-mixpanel-to-ducklake-saturn-mixpanel--pr-bbf9ogpi` on `meltano-workers-private`, 2026-04-30 19:46 UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)