### PR TITLE
Use SET GLOBAL for pg_pool_* options so they reach DuckLake's pool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,4 +101,4 @@ The ADC path (`_use_definite_gcp_credential_chain()`) exists because Definite st
 
 ## Key Dependencies
 
-- `duckdb==1.5.1`, `singer-sdk~=0.46.4`, `pyarrow>=20.0.0`, `polars>=1.31.0`, `sqlalchemy>=2.0.41`
+- `duckdb>=1.5.2,<1.6.0`, `singer-sdk~=0.46.4`, `pyarrow>=20.0.0`, `polars>=1.31.0`, `sqlalchemy>=2.0.41`

--- a/target_ducklake/connector.py
+++ b/target_ducklake/connector.py
@@ -197,11 +197,63 @@ class DuckLakeConnector(SQLConnector):
             startup_script = self._build_startup_script()
             conn.execute(startup_script)
 
+            self._log_pool_settings(conn)
+
             return conn
         except Exception as e:
             raise DuckLakeConnectorError(
                 f"Failed to create DuckDB connection: {e}"
             ) from e
+
+    def _log_pool_settings(self, conn: duckdb.DuckDBPyConnection) -> None:
+        """Log the resolved values of the postgres pool settings.
+
+        Diagnostic for verifying that SET pg_pool_* statements actually landed
+        before the PostgresConnectionPool was constructed (which happens at
+        ATTACH time and snapshots these values for the life of the pool).
+        """
+        settings = [
+            "pg_pool_enable_reaper_thread",
+            "pg_pool_idle_timeout_millis",
+            "pg_pool_max_connections",
+            "pg_pool_max_lifetime_millis",
+            "pg_pool_wait_timeout_millis",
+            "pg_pool_enable_thread_local_cache",
+            "pg_connection_limit",
+        ]
+        select_list = ", ".join(f"current_setting('{s}') AS {s}" for s in settings)
+        try:
+            row = conn.execute(f"SELECT {select_list}").fetchone()
+        except Exception:
+            logger.exception("Failed to read pool settings for diagnostic")
+            return
+        resolved = ", ".join(
+            f"{name}={value}" for name, value in zip(settings, row or [], strict=False)
+        )
+        logger.info("Resolved postgres pool settings after startup: %s", resolved)
+
+        # Live pool state: reaper_thread_running, available_connections, etc.
+        # postgres_configure_pool() with no args returns one row per attached
+        # postgres catalog. If `reaper_thread_running` is False here despite
+        # pg_pool_enable_reaper_thread=True, the reaper failed to start and
+        # idle connections will accumulate.
+        try:
+            pool_rows = conn.execute(
+                "SELECT catalog_name, available_connections, max_connections, "
+                "thread_local_cache_enabled, idle_timeout_millis, "
+                "max_lifetime_millis, reaper_thread_running "
+                "FROM postgres_configure_pool()"
+            ).fetchall()
+        except Exception:
+            logger.exception("Failed to read postgres_configure_pool() for diagnostic")
+            return
+        for pool_row in pool_rows:
+            logger.info("Live postgres pool state: %s", dict(zip(
+                ["catalog_name", "available_connections", "max_connections",
+                 "thread_local_cache_enabled", "idle_timeout_millis",
+                 "max_lifetime_millis", "reaper_thread_running"],
+                pool_row, strict=False,
+            )))
 
     def _build_attach_statement(self, data_path: str | None = None) -> str:
         """Build the ATTACH statement for the DuckLake catalog."""
@@ -245,8 +297,19 @@ class DuckLakeConnector(SQLConnector):
             "LOAD ducklake;",
             "LOAD postgres;",
             "SET ducklake_max_retry_count=100;",
-            # Restore pre-1.5.2 default (duckdb-postgres #427 dropped it to max(num_cpus, 8))
-            "SET pg_pool_max_connections=64;",
+            # SET GLOBAL is required on duckdb-postgres < f81dd35 (2026-04-20):
+            # before that fix, pg_pool_* options register with default (SESSION)
+            # scope, so plain SET only writes to the user's session — DuckLake's
+            # internal child Connection that runs the postgres ATTACH won't see
+            # them and the pool is built with defaults (no reaper, max=10).
+            "SET GLOBAL pg_pool_max_connections=64;",
+            "SET GLOBAL pg_pool_idle_timeout_millis=60000;",
+            "SET GLOBAL pg_pool_enable_reaper_thread=true;",
+            # Disable the thread-local cache: connections parked in per-thread
+            # caches are invisible to the reaper (it only iterates `available`)
+            # and only get evicted when that same thread acquires again. With
+            # parallel draining, idle threads leak their cached connection.
+            "SET GLOBAL pg_pool_enable_thread_local_cache=false;",
             self._build_attach_statement(data_path=data_path),
             (
                 "CREATE SECRET ("
@@ -268,8 +331,15 @@ class DuckLakeConnector(SQLConnector):
             "INSTALL postgres;",
             "LOAD postgres;",
             "SET ducklake_max_retry_count=100;",
-            # Restore pre-1.5.2 default (duckdb-postgres #427 dropped it to max(num_cpus, 8))
-            "SET pg_pool_max_connections=64;",
+            # SET GLOBAL is required on duckdb-postgres < f81dd35 (2026-04-20):
+            # before that fix, pg_pool_* options register with default (SESSION)
+            # scope, so plain SET only writes to the user's session — DuckLake's
+            # internal child Connection that runs the postgres ATTACH won't see
+            # them and the pool is built with defaults (no reaper, max=10).
+            "SET GLOBAL pg_pool_max_connections=64;",
+            "SET GLOBAL pg_pool_idle_timeout_millis=60000;",
+            "SET GLOBAL pg_pool_enable_reaper_thread=true;",
+            "SET GLOBAL pg_pool_enable_thread_local_cache=false;",
         ]
 
         script_parts.append(self._build_attach_statement())


### PR DESCRIPTION
> ⚠️ **Experimental — do not merge yet.** This branch is being pointed at by `meltano-extract-staging` for live testing. We'll merge into `main` once we've verified in staging that idle Postgres connections actually get reaped under real workloads.

## Summary

- Switches the `pg_pool_*` SET statements in the DuckDB startup script to `SET GLOBAL` so the values land in `DBConfig` (visible to every `ClientContext`), not just the current session.
- Adds a `_log_pool_settings()` diagnostic that logs `current_setting(...)` plus live `postgres_configure_pool()` state right after the startup script — useful for future regressions.

## Why this is necessary (and temporary)

target-ducklake's startup script issues `ATTACH 'ducklake:postgres:...'` which creates a DuckLake catalog. Internally, DuckLake's initializer spawns its **own child duckdb `Connection`** (`make_uniq<Connection>(db)` in [`ducklake_initializer.cpp`](https://github.com/duckdb/ducklake/blob/main/src/storage/ducklake_initializer.cpp)) to run `ATTACH OR REPLACE 'postgres:...' AS __ducklake_metadata_ducklake_catalog`. That ATTACH is what actually constructs the `PostgresConnectionPool` for the metadata catalog.

On the duckdb-postgres commit pinned by **duckdb 1.5.2** (`c89234f`, 2026-04-08), the `pg_pool_*` extension options are registered without `SetScope::GLOBAL`, so plain `SET` writes to the issuing session's `user_settings`. DuckLake's child `Connection` has its own `ClientContext` and never sees those values — the pool is constructed with **defaults**: `max_connections=10`, `idle_timeout=0`, no reaper, thread-local cache enabled. The result is idle Postgres backends accumulating against the catalog DB and never getting reaped.

We diagnosed this with `FROM postgres_configure_pool()`, which reports the live pool state per attached postgres catalog. Before this PR:

```
{'catalog_name': '__ducklake_metadata_ducklake_catalog',
 'available_connections': 0, 'max_connections': 10,
 'thread_local_cache_enabled': True, 'idle_timeout_millis': 0,
 'max_lifetime_millis': 0, 'reaper_thread_running': False}
```

After the `SET GLOBAL` switch, the same diagnostic returns the configured values and `reaper_thread_running=True`.

The upstream fix is duckdb-postgres commit [`f81dd35`](https://github.com/duckdb/duckdb-postgres/commit/f81dd35) (2026-04-20) — "Make connection pool options GLOBAL" — which annotates the option registrations with `SetScope::GLOBAL`. That landed **a week after** duckdb 1.5.2 was tagged (2026-04-13) and hasn't yet shipped in any duckdb release. Once a duckdb release pins a postgres_scanner commit ≥ `f81dd35`, plain `SET` will start working again and the `GLOBAL` keyword can be dropped (no functional change either way — `SET GLOBAL` continues to work).

This PR also disables the thread-local cache (`pg_pool_enable_thread_local_cache=false`) because the reaper only iterates the central `available` deque — connections parked in per-thread caches are invisible to it and only get evicted when that same thread acquires again. With parallel draining, idle threads were leaking their cached connection. Tradeoff is a microsecond of extra mutex contention on each acquire/return, which is negligible given target-ducklake's per-borrow workload.

## Test plan

- [ ] Point `meltano-extract-staging` at this branch and let it run.
- [ ] Confirm the new diagnostic log line `Live postgres pool state: ...` shows `max_connections=64`, `idle_timeout_millis=10000` (or 60000 on the GCP path), `reaper_thread_running=True`, `thread_local_cache_enabled=False`.
- [ ] In the catalog Postgres, run `SELECT pid, state, age(now(), state_change) FROM pg_stat_activity WHERE datname = 'ducklake_catalog' AND state = 'idle'` during a quiet period — idle backends >10s old should be reaped, not accumulate.
- [ ] Existing test suite passes: `uv run pytest tests/ -v`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)