### PR TITLE
remove Definite-specific GCS ADC path and meta_role

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,24 +81,6 @@ When `catalog_type` is `postgres`, column names longer than 63 characters are au
 - Implementation: `truncate_column_names()` in `flatten.py`, called via `ducklakeSink._apply_column_name_truncation()` in `sinks.py`
 - The truncation mapping is also applied to `key_properties` and to each record in `process_record()`
 
-## GCS Authentication (Definite-specific)
-
-When `storage_type` is `GCS`, the connector supports two authentication modes:
-
-| HMAC keys provided? | Behavior |
-|---|---|
-| Both `public_key` + `secret_key` set | **Legacy path** — public ducklake extension + `TYPE gcs` HMAC secret |
-| Neither set | **ADC path** — Definite-hosted ducklake/gcs extensions + `TYPE GCP, PROVIDER credential_chain` secret (uses GKE service account) |
-
-The ADC path (`_use_definite_gcp_credential_chain()`) exists because Definite stopped provisioning HMAC keys for new DuckLake integrations (2026-04-08). Key details:
-
-- Extensions are installed from `DEFINITE_EXTENSION_REPO` (`https://storage.googleapis.com/def-duckdb-extensions`) — the public httpfs-based ducklake doesn't support `TYPE GCP` secrets
-- `allow_unsigned_extensions` is enabled on the DuckDB connection for the Definite-hosted builds
-- Data paths are rewritten from `gs://` to `gcss://` (required by the native `gcs` extension)
-- Mirrors the canonical pattern from defapi `integration_config.py:135-146`
-- Implementation: `_build_gcp_credential_chain_script()` in `connector.py`, with shared `_build_attach_statement()` for the ATTACH logic
-- S3 and local storage paths are completely unchanged
-
 ## Key Dependencies
 
 - `duckdb>=1.5.2,<1.6.0`, `singer-sdk~=0.46.4`, `pyarrow>=20.0.0`, `polars>=1.31.0`, `sqlalchemy>=2.0.41`

--- a/target_ducklake/connector.py
+++ b/target_ducklake/connector.py
@@ -16,14 +16,6 @@ logger = logging.getLogger(__name__)
 
 PARTITION_GRANULARITIES = ["year", "month", "day", "hour"]
 
-# Definite-hosted DuckDB extension repo.
-# Used when authenticating to GCS via Application Default Credentials
-# (credential_chain) instead of HMAC keys. The native `gcs` extension
-# from this repo + the matching `ducklake` extension are required
-# because the public httpfs-based ducklake build does not understand
-# `TYPE GCP` secrets.
-DEFINITE_EXTENSION_REPO = "'https://storage.googleapis.com/def-duckdb-extensions'"
-
 # Postgres error messages that indicate transient connectivity issues.
 # These surface as plain duckdb.Error (not IOException) when DuckLake's
 # internal snapshot query hits a dropped Postgres connection.
@@ -112,7 +104,6 @@ class DuckLakeConnector(SQLConnector):
         self._connection: duckdb.DuckDBPyConnection | None = None
         self.catalog_name = "ducklake_catalog"
         self.meta_schema = config.get("meta_schema")
-        self.meta_role = config.get("meta_role")
 
     def _validate_config(self) -> None:
         """Validate required configuration parameters."""
@@ -166,33 +157,11 @@ class DuckLakeConnector(SQLConnector):
             logger.info("DuckDB and DuckLake catalog connection created.")
         return self._connection
 
-    def _use_definite_gcp_credential_chain(self) -> bool:
-        """Return True when GCS is configured without explicit HMAC keys.
-
-        In this mode we install the Definite-hosted ducklake/gcs extensions
-        and create a `TYPE GCP` secret backed by Application Default
-        Credentials (e.g., the GKE service account on meltano workers).
-        """
-        return (
-            self.storage_type == "GCS"
-            and not self.public_key
-            and not self.secret_key
-        )
-
     def _create_connection(self) -> duckdb.DuckDBPyConnection:
         """Create and configure a new DuckDB connection."""
         try:
             logger.info("Creating DuckDB connection")
-            if self._use_definite_gcp_credential_chain():
-                # Required to install the unsigned, Definite-hosted ducklake/gcs builds.
-                conn = duckdb.connect(
-                    database=":memory:",
-                    config={"allow_unsigned_extensions": True},
-                )
-            else:
-                # Legacy path: don't pass `config` at all, so behavior is bit-identical
-                # to pre-PR for customers on the HMAC / S3 / local flows.
-                conn = duckdb.connect(database=":memory:")
+            conn = duckdb.connect(database=":memory:")
 
             # Execute startup script to configure DuckLake
             startup_script = self._build_startup_script()
@@ -204,7 +173,7 @@ class DuckLakeConnector(SQLConnector):
                 f"Failed to create DuckDB connection: {e}"
             ) from e
 
-    def _build_attach_statement(self, data_path: str | None = None) -> str:
+    def _build_attach_statement(self) -> str:
         """Build the ATTACH statement for the DuckLake catalog."""
         if self.catalog_type == "duckdb":
             logger.info(
@@ -213,65 +182,19 @@ class DuckLakeConnector(SQLConnector):
             return f"ATTACH 'ducklake:metadata.ducklake' AS {self.catalog_name};"
 
         attach_params = {
-            "DATA_PATH": f"'{data_path or self.data_path}'",
+            "DATA_PATH": f"'{self.data_path}'",
             "DATA_INLINING_ROW_LIMIT": 0,
         }
         if self.meta_schema:
             attach_params["META_SCHEMA"] = f"'{self.meta_schema}'"
-        if self.meta_role:
-            attach_params["META_ROLE"] = f"'{self.meta_role}'"
 
         params_str = ", ".join(
             f"{key} {value}" for key, value in attach_params.items()
         )
         return f"ATTACH 'ducklake:{self.catalog_type}:{self.catalog_url}' AS {self.catalog_name} ({params_str});"
 
-    def _build_gcp_credential_chain_script(self) -> str:
-        """Build startup script for GCS with Application Default Credentials.
-
-        Uses Definite-hosted ducklake/gcs extensions that support `TYPE GCP`
-        secrets and the `gcss://` URI scheme. The public httpfs-based ducklake
-        only understands `TYPE gcs` HMAC + `gs://`.
-        Mirrors defapi `integration_config.py:135-146`.
-        """
-        data_path = self.data_path or ""
-        if data_path.startswith("gs://"):
-            data_path = "gcss://" + data_path[len("gs://"):]
-        script_parts = [
-            "INSTALL httpfs;",
-            f"INSTALL gcs FROM {DEFINITE_EXTENSION_REPO};",
-            f"INSTALL ducklake FROM {DEFINITE_EXTENSION_REPO};",
-            "INSTALL postgres;",
-            "LOAD httpfs;",
-            "LOAD gcs;",
-            "LOAD ducklake;",
-            "LOAD postgres;",
-            "SET ducklake_max_retry_count=100;",
-            # SET GLOBAL is required on duckdb-postgres < f81dd35 (2026-04-20):
-            # before that fix, pg_pool_* options register with default (SESSION)
-            # scope, so plain SET only writes to the user's session — DuckLake's
-            # internal child Connection that runs the postgres ATTACH won't see
-            # them and the pool is built with defaults (no reaper, max=10).
-            "SET GLOBAL pg_pool_max_connections=64;",
-            "SET GLOBAL pg_pool_idle_timeout_millis=60000;",
-            "SET GLOBAL pg_pool_enable_reaper_thread=true;",
-            "SET GLOBAL pg_pool_enable_thread_local_cache=false;",
-            self._build_attach_statement(data_path=data_path),
-            (
-                "CREATE SECRET ("
-                "TYPE GCP, "
-                "PROVIDER credential_chain, "
-                f"SCOPE '{data_path}'"
-                ");"
-            ),
-        ]
-        return "\n".join(script_parts)
-
     def _build_startup_script(self) -> str:
         """Build the DuckDB startup script with extensions and attachments."""
-        if self._use_definite_gcp_credential_chain():
-            return self._build_gcp_credential_chain_script()
-
         script_parts = [
             "INSTALL ducklake;",
             "INSTALL postgres;",

--- a/target_ducklake/target.py
+++ b/target_ducklake/target.py
@@ -93,16 +93,6 @@ class Targetducklake(SQLTarget):
                 title="Meta Schema",
                 description="Schema name in the catalog database to use for Ducklakemetadata tables",
             ),
-            th.Property(
-                "meta_role",
-                th.StringType(nullable=True),
-                title="Meta Role",
-                description=(
-                    "Optional Postgres role that the Definite-forked DuckLake "
-                    "extension assumes via SET LOCAL ROLE on every metadata "
-                    "transaction."
-                ),
-            ),
         th.Property(
             "data_path",
             th.StringType(nullable=False),

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -759,101 +759,34 @@ class TestTruncateColumnNames:
             assert long_key not in sink.flatten_schema
             assert "a" * 63 in sink.flatten_schema
 
-class TestStartupScriptGCSCredentialChain:
-    """Verify GCS-without-HMAC mode installs Definite extensions and creates a GCP secret."""
+class TestStartupScriptGCS:
+    """Verify GCS HMAC startup script wiring."""
 
     def _make_connector(self, **overrides):
         config = {
             "catalog_url": "host:5432/db",
             "data_path": "gs://def-ducklake/team-abc",
             "storage_type": "GCS",
+            "public_key": "ak",
+            "secret_key": "sk",
         }
         config.update(overrides)
         return DuckLakeConnector(config=config)
 
-    def test_credential_chain_mode_when_no_hmac_keys(self):
-        """No HMAC keys -> install custom extensions + TYPE GCP credential_chain SECRET.
-
-        Also verifies the data path is rewritten from `gs://` to `gcss://` for both
-        the ATTACH and the SECRET scope: the native gcs extension (used by the
-        custom ducklake build) only resolves `gcss://` URIs.
-        """
+    def test_hmac_path(self):
+        """With HMAC keys, install public ducklake extension and create a TYPE gcs secret."""
         connector = self._make_connector()
         script = connector._build_startup_script()
 
-        assert "INSTALL gcs FROM 'https://storage.googleapis.com/def-duckdb-extensions'" in script
-        assert "INSTALL ducklake FROM 'https://storage.googleapis.com/def-duckdb-extensions'" in script
-        assert "LOAD ducklake" in script
-        assert "TYPE GCP" in script
-        assert "PROVIDER credential_chain" in script
-        assert "SCOPE 'gcss://def-ducklake/team-abc'" in script
-        assert "DATA_PATH 'gcss://def-ducklake/team-abc'" in script
-        assert "DATA_PATH 'gs://" not in script  # must not leak the httpfs scheme
-        # Must NOT use the legacy HMAC pattern
-        assert "TYPE gcs," not in script
-        assert "KEY_ID" not in script
-
-    def test_legacy_hmac_path_unchanged_when_keys_present(self):
-        """With both HMAC keys, behavior matches the original path (no custom repo)."""
-        connector = self._make_connector(public_key="ak", secret_key="sk")
-        script = connector._build_startup_script()
-
         assert "INSTALL ducklake;" in script
-        assert "FROM 'https://storage.googleapis.com/def-duckdb-extensions'" not in script
         assert "TYPE gcs," in script
         assert "KEY_ID 'ak'" in script
-        assert "TYPE GCP" not in script
+        assert "DATA_PATH 'gs://def-ducklake/team-abc'" in script
 
-    def test_credential_chain_includes_meta_schema(self):
+    def test_includes_meta_schema(self):
         """META_SCHEMA should appear in the ATTACH statement when configured."""
         connector = self._make_connector(meta_schema="custom_meta")
         script = connector._build_startup_script()
 
         assert "META_SCHEMA 'custom_meta'" in script
-        assert "DATA_PATH 'gcss://def-ducklake/team-abc'" in script
-
-    def test_legacy_path_includes_meta_schema(self):
-        """META_SCHEMA should appear in the ATTACH statement on the legacy HMAC path."""
-        connector = self._make_connector(
-            public_key="ak", secret_key="sk", meta_schema="custom_meta"
-        )
-        script = connector._build_startup_script()
-
-        assert "META_SCHEMA 'custom_meta'" in script
         assert "DATA_PATH 'gs://def-ducklake/team-abc'" in script
-
-    def test_credential_chain_includes_meta_role_when_set(self):
-        """META_ROLE should appear in the ATTACH statement when configured."""
-        connector = self._make_connector(
-            meta_schema="custom_meta", meta_role="user_abc"
-        )
-        script = connector._build_startup_script()
-
-        assert "META_ROLE 'user_abc'" in script
-        assert "META_SCHEMA 'custom_meta'" in script
-        assert script.index("META_SCHEMA") < script.index("META_ROLE")
-
-    def test_credential_chain_omits_meta_role_when_unset(self):
-        """No META_ROLE clause unless the config explicitly provides one."""
-        connector = self._make_connector(meta_schema="custom_meta")
-        script = connector._build_startup_script()
-
-        assert "META_ROLE" not in script
-
-    def test_legacy_path_includes_meta_role_when_set(self):
-        """Legacy HMAC path also forwards META_ROLE through the ATTACH."""
-        connector = self._make_connector(
-            public_key="ak",
-            secret_key="sk",
-            meta_schema="custom_meta",
-            meta_role="user_abc",
-        )
-        script = connector._build_startup_script()
-
-        assert "META_ROLE 'user_abc'" in script
-        assert "DATA_PATH 'gs://def-ducklake/team-abc'" in script
-
-    def test_use_gcp_credential_chain_predicate(self):
-        assert self._make_connector()._use_definite_gcp_credential_chain() is True
-        assert self._make_connector(public_key="ak", secret_key="sk")._use_definite_gcp_credential_chain() is False
-        assert self._make_connector(storage_type="local", data_path="/tmp/x")._use_definite_gcp_credential_chain() is False


### PR DESCRIPTION
## Summary

Strip Definite-internal features from the public `main` branch. These features remain available on the new `definite` branch.

- **GCS ADC path**: `DEFINITE_EXTENSION_REPO` constant, `_use_definite_gcp_credential_chain()`, `_build_gcp_credential_chain_script()`, the \`allow_unsigned_extensions\` branch in `_create_connection`, and the `gs://` → `gcss://` rewrite. This auth mode used Definite-hosted DuckDB extensions to authenticate to GCS via Application Default Credentials and only makes sense in Definite's GKE environment.
- **`meta_role` config**: a Postgres role that the Definite-forked DuckLake extension assumed via \`SET LOCAL ROLE\`. Not supported by the public DuckLake build.
- Removed the corresponding "GCS Authentication (Definite-specific)" section from `CLAUDE.md`.
- Removed Definite-specific test cases; kept the generic GCS HMAC tests.

## Branch model

Companion branch `definite` was cut from `main` immediately before this PR. After this PR merges, `definite` will be synced via a follow-up `sync/main-into-definite` PR that resolves conflicts with the Definite versions.

## Test plan

- [x] `uv run pytest tests/ -v` — 45 passing
- [x] `uv run ruff check --fix --exit-non-zero-on-fix --show-fixes` — no new errors introduced (pre-existing warnings unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)