### PR TITLE
def: install ducklake/postgres from DEFINITE_EXTENSION_REPO in all startup paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,16 @@ The ADC path (`_use_definite_gcp_credential_chain()`) exists because Definite st
 - Implementation: `_build_gcp_credential_chain_script()` in `connector.py`, with shared `_build_attach_statement()` for the ATTACH logic
 - S3 and local storage paths still install ducklake/postgres from `DEFINITE_EXTENSION_REPO` but otherwise behave like before
 
+### Startup script ordering (do not reorder)
+
+The shared lines emitted by `_common_setup_lines()` rely on a specific order that the SQL semantics enforce:
+
+1. `LOAD postgres;` — must come before any `SET ... pg_pool_*` statement, since the pg_pool_* options are registered by the postgres extension.
+2. `SET GLOBAL pg_pool_*` — must come before `ATTACH 'ducklake:postgres:...'`, because DuckLake's internal child connection that runs the ATTACH reads pg_pool_* once at attach time. Setting them afterward has no effect on the pool that's already been built.
+3. `ATTACH` is appended by the caller after `_common_setup_lines()` returns.
+
+If you ever reorder these — even for cosmetic reasons — the pg_pool_* config is silently dropped and the pool is built with defaults (no reaper, max=10). Tests check substring presence, not order, so they will not catch this.
+
 ## Branch Model: `main` vs `definite`
 
 This repo has two long-lived branches:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,16 @@ The ADC path (`_use_definite_gcp_credential_chain()`) exists because Definite st
 - Implementation: `_build_gcp_credential_chain_script()` in `connector.py`, with shared `_build_attach_statement()` for the ATTACH logic
 - S3 and local storage paths still install ducklake/postgres from `DEFINITE_EXTENSION_REPO` but otherwise behave like before
 
+### Why `SET GLOBAL` for `pg_pool_*` (not plain `SET`)
+
+The startup script uses `SET GLOBAL pg_pool_max_connections=64;` (and the other `pg_pool_*` options) instead of plain `SET`. This is required on `duckdb-postgres` builds older than [commit f81dd35](https://github.com/duckdb/duckdb-postgres/commit/f81dd35) (2026-04-20):
+
+- Before that fix, `pg_pool_*` options were registered with default (SESSION) scope. Plain `SET pg_pool_*` would only update the user's current DuckDB session.
+- DuckLake's internal child `Connection` that runs the postgres `ATTACH` does **not** inherit user-session settings — it reads pg_pool_* from the GLOBAL scope only.
+- Result: with plain `SET`, the postgres extension's connection pool is built using defaults (`pg_pool_max_connections=10`, no reaper thread), regardless of what the script asked for.
+
+`SET GLOBAL` writes to the global scope, so DuckLake's child connection sees the configured values when it builds the pool. We can switch back to plain `SET` once we're guaranteed to be on a post-f81dd35 build — until then, keep `GLOBAL`.
+
 ### Startup script ordering (do not reorder)
 
 The shared lines emitted by `_common_setup_lines()` rely on a specific order that the SQL semantics enforce:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,21 +83,22 @@ When `catalog_type` is `postgres`, column names longer than 63 characters are au
 
 ## GCS Authentication (Definite-specific)
 
+`ducklake` and `postgres` are always installed from `DEFINITE_EXTENSION_REPO` (`https://storage.googleapis.com/def-duckdb-extensions`), regardless of which startup-script path runs. Because those builds are unsigned, every DuckDB connection is created with `allow_unsigned_extensions=True`.
+
 When `storage_type` is `GCS`, the connector supports two authentication modes:
 
 | HMAC keys provided? | Behavior |
 |---|---|
-| Both `public_key` + `secret_key` set | **Legacy path** — public ducklake extension + `TYPE gcs` HMAC secret |
-| Neither set | **ADC path** — Definite-hosted ducklake/gcs extensions + `TYPE GCP, PROVIDER credential_chain` secret (uses GKE service account) |
+| Both `public_key` + `secret_key` set | **Legacy path** — Definite-hosted ducklake/postgres + `TYPE gcs` HMAC secret over httpfs |
+| Neither set | **ADC path** — Definite-hosted ducklake/postgres/gcs + `TYPE GCP, PROVIDER credential_chain` secret (uses GKE service account) |
 
 The ADC path (`_use_definite_gcp_credential_chain()`) exists because Definite stopped provisioning HMAC keys for new DuckLake integrations (2026-04-08). Key details:
 
-- Extensions are installed from `DEFINITE_EXTENSION_REPO` (`https://storage.googleapis.com/def-duckdb-extensions`) — the public httpfs-based ducklake doesn't support `TYPE GCP` secrets
-- `allow_unsigned_extensions` is enabled on the DuckDB connection for the Definite-hosted builds
+- Adds `INSTALL gcs FROM DEFINITE_EXTENSION_REPO` on top of the always-installed ducklake/postgres — the public httpfs-based ducklake doesn't support `TYPE GCP` secrets
 - Data paths are rewritten from `gs://` to `gcss://` (required by the native `gcs` extension)
 - Mirrors the canonical pattern from defapi `integration_config.py:135-146`
 - Implementation: `_build_gcp_credential_chain_script()` in `connector.py`, with shared `_build_attach_statement()` for the ATTACH logic
-- S3 and local storage paths are completely unchanged
+- S3 and local storage paths still install ducklake/postgres from `DEFINITE_EXTENSION_REPO` but otherwise behave like before
 
 ## Branch Model: `main` vs `definite`
 

--- a/target_ducklake/connector.py
+++ b/target_ducklake/connector.py
@@ -183,18 +183,12 @@ class DuckLakeConnector(SQLConnector):
         """Create and configure a new DuckDB connection."""
         try:
             logger.info("Creating DuckDB connection")
-            if self._use_definite_gcp_credential_chain():
-                # Required to install the unsigned, Definite-hosted ducklake/gcs builds.
-                conn = duckdb.connect(
-                    database=":memory:",
-                    config={"allow_unsigned_extensions": True},
-                )
-            else:
-                # Legacy path: don't pass `config` at all, so behavior is bit-identical
-                # to pre-PR for customers on the HMAC / S3 / local flows.
-                conn = duckdb.connect(database=":memory:")
+            # Required to install the unsigned, Definite-hosted ducklake/postgres/gcs builds.
+            conn = duckdb.connect(
+                database=":memory:",
+                config={"allow_unsigned_extensions": True},
+            )
 
-            # Execute startup script to configure DuckLake
             startup_script = self._build_startup_script()
             conn.execute(startup_script)
 
@@ -241,7 +235,7 @@ class DuckLakeConnector(SQLConnector):
             "INSTALL httpfs;",
             f"INSTALL gcs FROM {DEFINITE_EXTENSION_REPO};",
             f"INSTALL ducklake FROM {DEFINITE_EXTENSION_REPO};",
-            "INSTALL postgres;",
+            f"INSTALL postgres FROM {DEFINITE_EXTENSION_REPO};",
             "LOAD httpfs;",
             "LOAD gcs;",
             "LOAD ducklake;",
@@ -273,8 +267,8 @@ class DuckLakeConnector(SQLConnector):
             return self._build_gcp_credential_chain_script()
 
         script_parts = [
-            "INSTALL ducklake;",
-            "INSTALL postgres;",
+            f"INSTALL ducklake FROM {DEFINITE_EXTENSION_REPO};",
+            f"INSTALL postgres FROM {DEFINITE_EXTENSION_REPO};",
             "LOAD postgres;",
             "SET ducklake_max_retry_count=100;",
             # SET GLOBAL is required on duckdb-postgres < f81dd35 (2026-04-20):

--- a/target_ducklake/connector.py
+++ b/target_ducklake/connector.py
@@ -220,6 +220,31 @@ class DuckLakeConnector(SQLConnector):
         )
         return f"ATTACH 'ducklake:{self.catalog_type}:{self.catalog_url}' AS {self.catalog_name} ({params_str});"
 
+    def _common_setup_lines(self) -> list[str]:
+        """Shared INSTALL + LOAD + pool settings used by every startup path.
+
+        SET GLOBAL is required on duckdb-postgres < f81dd35 (2026-04-20): before
+        that fix, pg_pool_* options register with default (SESSION) scope, so
+        plain SET only writes to the user's session — DuckLake's internal child
+        Connection that runs the postgres ATTACH won't see them and the pool is
+        built with defaults (no reaper, max=10).
+
+        REQUIRED ORDER: ``LOAD postgres`` → ``SET GLOBAL pg_pool_*`` → ``ATTACH``
+        (the caller appends ATTACH). Reordering silently breaks the pool config.
+        """
+        return [
+            f"INSTALL ducklake FROM {DEFINITE_EXTENSION_REPO};",
+            f"INSTALL postgres FROM {DEFINITE_EXTENSION_REPO};",
+            # Order matters below: LOAD postgres must precede SET GLOBAL pg_pool_*,
+            # and both must precede ATTACH (which the caller appends).
+            "LOAD postgres;",
+            "SET ducklake_max_retry_count=100;",
+            "SET GLOBAL pg_pool_max_connections=64;",
+            "SET GLOBAL pg_pool_idle_timeout_millis=60000;",
+            "SET GLOBAL pg_pool_enable_reaper_thread=true;",
+            "SET GLOBAL pg_pool_enable_thread_local_cache=false;",
+        ]
+
     def _build_gcp_credential_chain_script(self) -> str:
         """Build startup script for GCS with Application Default Credentials.
 
@@ -234,30 +259,12 @@ class DuckLakeConnector(SQLConnector):
         script_parts = [
             "INSTALL httpfs;",
             f"INSTALL gcs FROM {DEFINITE_EXTENSION_REPO};",
-            f"INSTALL ducklake FROM {DEFINITE_EXTENSION_REPO};",
-            f"INSTALL postgres FROM {DEFINITE_EXTENSION_REPO};",
+            *self._common_setup_lines(),
             "LOAD httpfs;",
             "LOAD gcs;",
             "LOAD ducklake;",
-            "LOAD postgres;",
-            "SET ducklake_max_retry_count=100;",
-            # SET GLOBAL is required on duckdb-postgres < f81dd35 (2026-04-20):
-            # before that fix, pg_pool_* options register with default (SESSION)
-            # scope, so plain SET only writes to the user's session — DuckLake's
-            # internal child Connection that runs the postgres ATTACH won't see
-            # them and the pool is built with defaults (no reaper, max=10).
-            "SET GLOBAL pg_pool_max_connections=64;",
-            "SET GLOBAL pg_pool_idle_timeout_millis=60000;",
-            "SET GLOBAL pg_pool_enable_reaper_thread=true;",
-            "SET GLOBAL pg_pool_enable_thread_local_cache=false;",
             self._build_attach_statement(data_path=data_path),
-            (
-                "CREATE SECRET ("
-                "TYPE GCP, "
-                "PROVIDER credential_chain, "
-                f"SCOPE '{data_path}'"
-                ");"
-            ),
+            f"CREATE SECRET (TYPE GCP, PROVIDER credential_chain, SCOPE '{data_path}');",
         ]
         return "\n".join(script_parts)
 
@@ -266,45 +273,22 @@ class DuckLakeConnector(SQLConnector):
         if self._use_definite_gcp_credential_chain():
             return self._build_gcp_credential_chain_script()
 
-        script_parts = [
-            f"INSTALL ducklake FROM {DEFINITE_EXTENSION_REPO};",
-            f"INSTALL postgres FROM {DEFINITE_EXTENSION_REPO};",
-            "LOAD postgres;",
-            "SET ducklake_max_retry_count=100;",
-            # SET GLOBAL is required on duckdb-postgres < f81dd35 (2026-04-20):
-            # before that fix, pg_pool_* options register with default (SESSION)
-            # scope, so plain SET only writes to the user's session — DuckLake's
-            # internal child Connection that runs the postgres ATTACH won't see
-            # them and the pool is built with defaults (no reaper, max=10).
-            "SET GLOBAL pg_pool_max_connections=64;",
-            "SET GLOBAL pg_pool_idle_timeout_millis=60000;",
-            "SET GLOBAL pg_pool_enable_reaper_thread=true;",
-            "SET GLOBAL pg_pool_enable_thread_local_cache=false;",
-        ]
-
+        script_parts = self._common_setup_lines()
         script_parts.append(self._build_attach_statement())
 
-        # Add secrets for cloud storage if configured
         if self.public_key and self.secret_key:
             if self.storage_type == "GCS":
                 script_parts.append(
-                    f"CREATE SECRET ("
-                    f"TYPE gcs, "
-                    f"KEY_ID '{self.public_key}', "
-                    f"SECRET '{self.secret_key}'"
-                    ");"
+                    f"CREATE SECRET (TYPE gcs, KEY_ID '{self.public_key}', "
+                    f"SECRET '{self.secret_key}');"
                 )
             elif self.storage_type == "S3":
-                # For S3, region is required when using explicit credentials
-                secret_parts = [
-                    f"TYPE s3, KEY_ID '{self.public_key}'",
-                    f"SECRET '{self.secret_key}'",
-                    f"REGION '{self.region}'",  # Always include since we validate it's required
-                ]
-
-                script_parts.append("CREATE SECRET (" + ", ".join(secret_parts) + ");")
+                # region required for S3 (validated in _validate_config)
+                script_parts.append(
+                    f"CREATE SECRET (TYPE s3, KEY_ID '{self.public_key}', "
+                    f"SECRET '{self.secret_key}', REGION '{self.region}');"
+                )
         elif self.storage_type in ["GCS", "S3"]:
-            # Log info when cloud storage is configured but no auth is provided
             logger.info(
                 f"Storage type is {self.storage_type} but no authentication credentials provided. "
                 f"Will attempt to access storage without explicit authentication. "

--- a/tests/test_comprehensive.py
+++ b/tests/test_comprehensive.py
@@ -783,6 +783,7 @@ class TestStartupScriptGCSCredentialChain:
 
         assert "INSTALL gcs FROM 'https://storage.googleapis.com/def-duckdb-extensions'" in script
         assert "INSTALL ducklake FROM 'https://storage.googleapis.com/def-duckdb-extensions'" in script
+        assert "INSTALL postgres FROM 'https://storage.googleapis.com/def-duckdb-extensions'" in script
         assert "LOAD ducklake" in script
         assert "TYPE GCP" in script
         assert "PROVIDER credential_chain" in script
@@ -793,13 +794,13 @@ class TestStartupScriptGCSCredentialChain:
         assert "TYPE gcs," not in script
         assert "KEY_ID" not in script
 
-    def test_legacy_hmac_path_unchanged_when_keys_present(self):
-        """With both HMAC keys, behavior matches the original path (no custom repo)."""
+    def test_legacy_hmac_path_uses_definite_extensions(self):
+        """With HMAC keys, ducklake/postgres still come from DEFINITE_EXTENSION_REPO."""
         connector = self._make_connector(public_key="ak", secret_key="sk")
         script = connector._build_startup_script()
 
-        assert "INSTALL ducklake;" in script
-        assert "FROM 'https://storage.googleapis.com/def-duckdb-extensions'" not in script
+        assert "INSTALL ducklake FROM 'https://storage.googleapis.com/def-duckdb-extensions'" in script
+        assert "INSTALL postgres FROM 'https://storage.googleapis.com/def-duckdb-extensions'" in script
         assert "TYPE gcs," in script
         assert "KEY_ID 'ak'" in script
         assert "TYPE GCP" not in script


### PR DESCRIPTION
## Summary

Two related changes on the `def/custom-extensions` branch, organized as three commits:

**1. Unify extension sourcing.** Make `ducklake` and `postgres` always come from `DEFINITE_EXTENSION_REPO` (the Definite-hosted DuckDB extension repo), regardless of which startup-script path runs. Previously only the GCS ADC path used Definite-hosted `ducklake`/`gcs`, while `postgres` everywhere and `ducklake` on the regular HMAC path came from the default DuckDB repo.

**2. Consolidate the duplicated startup-script chunks** introduced by (1) into a single `_common_setup_lines()` helper, and document the non-obvious invariants (ordering and `SET GLOBAL` rationale) in CLAUDE.md.

## connector.py

### Extension sourcing
- `_create_connection`: dropped the conditional. All connections now pass `config={"allow_unsigned_extensions": True}` since both paths load Definite-hosted (unsigned) builds.
- `_build_gcp_credential_chain_script`: `INSTALL postgres;` → `INSTALL postgres FROM DEFINITE_EXTENSION_REPO;` (`gcs` and `ducklake` were already from there).
- `_build_startup_script` (regular path): `INSTALL ducklake;` and `INSTALL postgres;` both updated to `FROM DEFINITE_EXTENSION_REPO`.

`gcs` is *not* added to the regular path — that path still uses httpfs + `TYPE gcs` HMAC secret as today. `httpfs` continues to come from DuckDB's default repo.

### Refactor
- New `_common_setup_lines()` helper holds the eight lines shared between both startup builders: `INSTALL ducklake/postgres FROM DEFINITE_EXTENSION_REPO`, `LOAD postgres`, `SET ducklake_max_retry_count`, and the four `SET GLOBAL pg_pool_*` lines (plus the previously-duplicated multiline comment, now a single docstring).
- Both startup builders use it. Behavior is preserved — the only change is that `LOAD postgres` now appears before `LOAD httpfs/gcs/ducklake` in the credential_chain script (semantically equivalent; extension loads are independent).
- Folded the S3 `secret_parts` list into a single f-string while in the area.
- Net `connector.py` change: −51 / +45 lines.

## tests/test_comprehensive.py

- Renamed `test_legacy_hmac_path_unchanged_when_keys_present` → `test_legacy_hmac_path_uses_definite_extensions`. The old name and assertions (`INSTALL ducklake;` and "FROM ...def-duckdb-extensions" *not* in script) are no longer accurate.
- Added `INSTALL postgres FROM ...` assertion to `test_credential_chain_mode_when_no_hmac_keys`.

## CLAUDE.md

- Updated the GCS Authentication section: `allow_unsigned_extensions` is always on, and `ducklake`/`postgres` come from the Definite repo on both paths.
- New **"Why `SET GLOBAL` for `pg_pool_*`"** subsection — explains why we can't use plain `SET` (duckdb-postgres < f81dd35 registers pg_pool_* in SESSION scope, so DuckLake's internal child connection wouldn't see the values). Previously this lived only in an inline comment.
- New **"Startup script ordering (do not reorder)"** subsection — captures the `LOAD postgres` → `SET GLOBAL pg_pool_*` → `ATTACH` invariant. Tests check substring presence, not order, so this is easy to break silently.

## Commits

1. `def: install ducklake/postgres from DEFINITE_EXTENSION_REPO in all startup paths`
2. `refactor: extract _common_setup_lines helper for shared startup chunks`
3. `docs: explain why pg_pool_* uses SET GLOBAL in CLAUDE.md`

## Test plan

- [x] `uv run pytest tests/ -v` — 51 passing (including all Definite-specific tests)
- [x] Verified both startup paths now contain `INSTALL ducklake FROM 'https://storage.googleapis.com/def-duckdb-extensions'` and `INSTALL postgres FROM 'https://storage.googleapis.com/def-duckdb-extensions'`.
- [x] Spot-checked the rendered scripts before and after the refactor; identical except for the cosmetic `LOAD postgres` reordering called out above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)