### PR TITLE
def: clarify LOAD postgres ordering with DuckDB source citations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,13 +112,17 @@ The startup script uses `SET GLOBAL pg_pool_max_connections=64;` (and the other 
 
 ### Startup script ordering (do not reorder)
 
-The shared lines emitted by `_common_setup_lines()` rely on a specific order that the SQL semantics enforce:
+The shared lines emitted by `_common_setup_lines()` rely on a specific order that DuckDB's extension manager and the SQL semantics enforce:
 
-1. `LOAD postgres;` — must come before any `SET ... pg_pool_*` statement, since the pg_pool_* options are registered by the postgres extension.
-2. `SET GLOBAL pg_pool_*` — must come before `ATTACH 'ducklake:postgres:...'`, because DuckLake's internal child connection that runs the ATTACH reads pg_pool_* once at attach time. Setting them afterward has no effect on the pool that's already been built.
-3. `ATTACH` is appended by the caller after `_common_setup_lines()` returns.
+1. **`LOAD postgres;` (Definite fork) must come before the first `ATTACH` that references a postgres-typed catalog** — including the metadata `ATTACH 'postgres:...'` that DuckLake issues during catalog initialization. DuckDB's `ExtensionManager::BeginLoad` short-circuits on already-loaded extensions ([`extension_manager.cpp:73-110`](https://github.com/duckdb/duckdb/blob/main/src/main/extension_manager.cpp#L73-L110)), and `loaded_extensions_info` is keyed only by extension name (no repo/version). Once postgres is loaded, no later `LOAD postgres` or `INSTALL postgres FROM <other-repo>` swaps the in-memory binary — `INSTALL` only writes to disk ([`extension_install.cpp`](https://github.com/duckdb/duckdb/blob/main/src/main/extension/extension_install.cpp)). So the *first* postgres binary the manager registers is the one bound for the lifetime of that `DatabaseInstance`. If `ATTACH` triggers `TryAutoLoadExtension` first ([`database_manager.cpp:174-187`](https://github.com/duckdb/duckdb/blob/main/src/main/database_manager.cpp#L174-L187)), DuckDB may pull upstream postgres instead of our Definite build, and `META_ROLE` (which exists only on the Definite fork) silently stops working.
 
-If you ever reorder these — even for cosmetic reasons — the pg_pool_* config is silently dropped and the pool is built with defaults (no reaper, max=10). Tests check substring presence, not order, so they will not catch this.
+2. `LOAD postgres;` must come before any `SET ... pg_pool_*` statement — the pg_pool_* options are registered by the postgres extension and don't exist as settings until it's loaded.
+
+3. `SET GLOBAL pg_pool_*` must come before `ATTACH 'ducklake:postgres:...'` — DuckLake's internal child connection that runs the ATTACH reads pg_pool_* once at attach time. Setting them afterward has no effect on the pool that's already been built.
+
+4. `ATTACH` is appended by the caller after `_common_setup_lines()` returns.
+
+Net rule: **`LOAD postgres` first, before everything else that touches postgres state.** Tests check substring presence, not order, so reordering will pass CI and silently break META_ROLE and/or pg_pool_* in production. To recover from a wrong-binary load you have to create a fresh `DatabaseInstance` (close + reopen the connection) — there is no in-process swap.
 
 ## Branch Model: `main` vs `definite`
 

--- a/target_ducklake/connector.py
+++ b/target_ducklake/connector.py
@@ -223,20 +223,16 @@ class DuckLakeConnector(SQLConnector):
     def _common_setup_lines(self) -> list[str]:
         """Shared INSTALL + LOAD + pool settings used by every startup path.
 
-        SET GLOBAL is required on duckdb-postgres < f81dd35 (2026-04-20): before
-        that fix, pg_pool_* options register with default (SESSION) scope, so
-        plain SET only writes to the user's session — DuckLake's internal child
-        Connection that runs the postgres ATTACH won't see them and the pool is
-        built with defaults (no reaper, max=10).
-
-        REQUIRED ORDER: ``LOAD postgres`` → ``SET GLOBAL pg_pool_*`` → ``ATTACH``
-        (the caller appends ATTACH). Reordering silently breaks the pool config.
+        Order is load-bearing: ``LOAD postgres`` (Definite fork) must come
+        before any ``ATTACH`` and before ``SET GLOBAL pg_pool_*``. See CLAUDE.md
+        "Startup script ordering" for the full rationale and source citations.
         """
         return [
             f"INSTALL ducklake FROM {DEFINITE_EXTENSION_REPO};",
             f"INSTALL postgres FROM {DEFINITE_EXTENSION_REPO};",
-            # Order matters below: LOAD postgres must precede SET GLOBAL pg_pool_*,
-            # and both must precede ATTACH (which the caller appends).
+            # LOAD postgres FIRST: first-loaded postgres binary is bound for the
+            # DatabaseInstance lifetime; later LOAD/INSTALL won't swap it. If we
+            # let ATTACH autoload upstream postgres instead, META_ROLE breaks.
             "LOAD postgres;",
             "SET ducklake_max_retry_count=100;",
             "SET GLOBAL pg_pool_max_connections=64;",


### PR DESCRIPTION
## Summary

After PR #70 landed the \`_common_setup_lines\` helper and a \"Startup script ordering\" note in CLAUDE.md, I researched the DuckDB source to verify a related claim from another project: that \`LOAD ducklake\` triggers a transitive postgres autoload and the *first* postgres LOAD wins for the process lifetime. Findings:

- **First-LOAD-wins is real** — \`ExtensionManager::BeginLoad\` short-circuits on already-loaded extensions and \`loaded_extensions_info\` is keyed only by extension name, not repo/version ([\`extension_manager.cpp:73-110\`](https://github.com/duckdb/duckdb/blob/main/src/main/extension_manager.cpp#L73-L110)).
- **\`INSTALL ... FROM <other-repo>\` after LOAD is a no-op for the in-memory binary** — \`INSTALL\` only writes to disk ([\`extension_install.cpp\`](https://github.com/duckdb/duckdb/blob/main/src/main/extension/extension_install.cpp)).
- **The autoload trigger is \`ATTACH\`, not literally \`LOAD ducklake\`** — DuckLake's \`Load()\` doesn't autoload postgres, but \`ATTACH 'ducklake:postgres:...'\` (and the metadata \`ATTACH 'postgres:...'\` ducklake issues during catalog init) calls \`TryAutoLoadExtension\` ([\`database_manager.cpp:174-187\`](https://github.com/duckdb/duckdb/blob/main/src/main/database_manager.cpp#L174-L187)).
- **\`META_ROLE\` does not exist in upstream \`duckdb/duckdb-postgres\`** — confirmed via grep on \`main\`. The option only works against the Definite fork.

## What's load-bearing

The previously documented ordering invariant (\`LOAD postgres → SET GLOBAL pg_pool_* → ATTACH\`) was incomplete. The fuller rule:

> **\`LOAD postgres\` (Definite fork) must happen before any \`ATTACH\` that references a postgres-typed catalog.** If \`ATTACH\` autoloads upstream postgres first, that binary is bound for the \`DatabaseInstance\` lifetime — no later \`LOAD\` or \`INSTALL FROM ...\` can swap it — and \`META_ROLE\` silently stops working.

Today's code already does this correctly (LOAD postgres sits in \`_common_setup_lines\` ahead of every ATTACH). This PR is documentation-only: it makes the constraint visible so a future refactor can't accidentally move LOAD postgres later.

## Changes

- **CLAUDE.md** — rewrote the \"Startup script ordering\" subsection with source citations and a clearer net rule.
- **connector.py** — tightened the docstring + inline comment on \`_common_setup_lines\` to summarize the rule and point to CLAUDE.md for the full rationale.

## Test plan

- [x] \`uv run pytest tests/ -v\` — 51 passing
- [x] No code-behavior changes; this is documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)